### PR TITLE
replaced coveralls badge with the one for the sftt repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/Code-4-Community/speak-for-the-trees-frontend.svg?branch=master)](https://travis-ci.org/Code-4-Community/frontend-scaffold)
 
-[![Coverage Status](https://coveralls.io/repos/github/Code-4-Community/speak-for-the-trees-frontend/badge.svg?branch=master)](https://coveralls.io/github/Code-4-Community/frontend-scaffold?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Code-4-Community/speak-for-the-trees-frontend/badge.svg?branch=master)](https://coveralls.io/github/Code-4-Community/speak-for-the-trees-frontend?branch=master)
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 


### PR DESCRIPTION
The coveralls badge was for the frontend-scaffold, switched the badge to represent coverage of this repo