### PR TITLE
Authentication for Protected Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ const { Content } = Layout;
 type AppProps = UserAuthenticationReducerState;
 
 const App: React.FC<AppProps> = ({ tokens }) => {
-  const privilegeLevel = useSelector((state: C4CState) =>
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(tokens),
   );
 
@@ -53,76 +53,70 @@ const App: React.FC<AppProps> = ({ tokens }) => {
               switch (privilegeLevel) {
                 case PrivilegeLevel.NONE:
                   return (
-                    <>
-                      <Switch>
-                        <Route path="/" exact component={Landing} />
-                        <Route path="/login" exact component={Login} />
-                        <Route path="/signup" exact component={Signup} />
-                        <Route path="/home">
-                          <Redirect to="/login" />
-                        </Route>
-                        <Route path="/settings">
-                          <Redirect to="/login" />
-                        </Route>
-                        <Route path="/volunteer">
-                          <Redirect to="/login" />
-                        </Route>
-                        <Route path="/admin">
-                          <Redirect to="/login" />
-                        </Route>
-                        <Route path="*" exact component={NotFound} />
-                      </Switch>
-                    </>
+                    <Switch>
+                      <Route path="/" exact component={Landing} />
+                      <Route path="/login" exact component={Login} />
+                      <Route path="/signup" exact component={Signup} />
+                      <Route path="/home">
+                        <Redirect to="/login" />
+                      </Route>
+                      <Route path="/settings">
+                        <Redirect to="/login" />
+                      </Route>
+                      <Route path="/volunteer">
+                        <Redirect to="/login" />
+                      </Route>
+                      <Route path="/admin">
+                        <Redirect to="/login" />
+                      </Route>
+                      <Route path="*" exact component={NotFound} />
+                    </Switch>
                   );
 
                 case PrivilegeLevel.STANDARD:
                   return (
-                    <>
-                      <Switch>
-                        <Route path="/" exact component={Landing} />
-                        <Route path="/login">
-                          <Redirect to="/home" />
-                        </Route>
-                        <Route path="/signup">
-                          <Redirect to="/home" />
-                        </Route>
-                        <Route path="/home" exact component={Home} />
-                        <Route path="/settings" exact component={Settings} />
-                        <Route
-                          path="/volunteer"
-                          exact
-                          component={VolunteerLeaderboard}
-                        />
-                        <Route path="/admin">
-                          <Redirect to="/home" />
-                        </Route>
-                        <Route path="*" exact component={NotFound} />
-                      </Switch>
-                    </>
+                    <Switch>
+                      <Route path="/" exact component={Landing} />
+                      <Route path="/login">
+                        <Redirect to="/home" />
+                      </Route>
+                      <Route path="/signup">
+                        <Redirect to="/home" />
+                      </Route>
+                      <Route path="/home" exact component={Home} />
+                      <Route path="/settings" exact component={Settings} />
+                      <Route
+                        path="/volunteer"
+                        exact
+                        component={VolunteerLeaderboard}
+                      />
+                      <Route path="/admin">
+                        <Redirect to="/home" />
+                      </Route>
+                      <Route path="*" exact component={NotFound} />
+                    </Switch>
                   );
 
                 case PrivilegeLevel.ADMIN:
                   return (
-                    <>
-                      <Switch>
-                        <Route path="/" exact component={Landing} />
-                        <Route path="/login">
-                          <Redirect to="/home" />
-                        </Route>
-                        <Route path="/signup">
-                          <Redirect to="/home" />
-                        </Route>
-                        <Route path="/home" exact component={Home} />
-                        <Route path="/settings" exact component={Settings} />
-                        <Route
-                          path="/volunteer"
-                          exact
-                          component={VolunteerLeaderboard}
-                        />
-                        <Route path="/admin" exact component={AdminDashboard} />
-                        <Route path="*" exact component={NotFound} />
-                      </Switch>
-                    </>
+                    <Switch>
+                      <Route path="/" exact component={Landing} />
+                      <Route path="/login">
+                        <Redirect to="/home" />
+                      </Route>
+                      <Route path="/signup">
+                        <Redirect to="/home" />
+                      </Route>
+                      <Route path="/home" exact component={Home} />
+                      <Route path="/settings" exact component={Settings} />
+                      <Route
+                        path="/volunteer"
+                        exact
+                        component={VolunteerLeaderboard}
+                      />
+                      <Route path="/admin" exact component={AdminDashboard} />
+                      <Route path="*" exact component={NotFound} />
+                    </Switch>
                   );
               }
             })()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { connect, useSelector } from 'react-redux';
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect,
+} from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import {
+  PrivilegeLevel,
+  UserAuthenticationReducerState,
+} from '../src/auth/ducks/types';
+import { getPrivilegeLevel } from '../src/auth/ducks/selectors';
+import { C4CState } from './store';
 
 import './App.less';
 import Landing from './containers/landing/Landing';
@@ -14,9 +26,16 @@ import VolunteerLeaderboard from './containers/volunteer-leaderboard/VolunteerLe
 import NotFound from './containers/not-found/NotFound';
 import NavBar from './components/nav-bar/NavBar';
 import { Layout } from 'antd';
+
 const { Content } = Layout;
 
-const App: React.FC = () => {
+type AppProps = UserAuthenticationReducerState;
+
+const App: React.FC<AppProps> = ({ tokens }) => {
+  const privilegeLevel = useSelector((state: C4CState) =>
+    getPrivilegeLevel(tokens),
+  );
+
   return (
     <>
       <Helmet>
@@ -26,21 +45,87 @@ const App: React.FC = () => {
         />
         <meta name="description" content="Speak for the Trees Website" />
       </Helmet>
-
       <Router>
         <Layout className="app-flex-container">
           <NavBar />
           <Content className="content-padding">
-            <Switch>
-              <Route path="/" exact component={Landing} />
-              <Route path="/login" exact component={Login} />
-              <Route path="/signup" exact component={Signup} />
-              <Route path="/home" exact component={Home} />
-              <Route path="/settings" exact component={Settings} />
-              <Route path="/volunteer" exact component={VolunteerLeaderboard} />
-              <Route path="/admin" exact component={AdminDashboard} />
-              <Route path="*" exact component={NotFound} />
-            </Switch>
+            {(() => {
+              switch (privilegeLevel) {
+                case PrivilegeLevel.NONE:
+                  return (
+                    <>
+                      <Switch>
+                        <Route path="/" exact component={Landing} />
+                        <Route path="/login" exact component={Login} />
+                        <Route path="/signup" exact component={Signup} />
+                        <Route path="/home">
+                          <Redirect to="/login" />
+                        </Route>
+                        <Route path="/settings">
+                          <Redirect to="/login" />
+                        </Route>
+                        <Route path="/volunteer">
+                          <Redirect to="/login" />
+                        </Route>
+                        <Route path="/admin">
+                          <Redirect to="/login" />
+                        </Route>
+                        <Route path="*" exact component={NotFound} />
+                      </Switch>
+                    </>
+                  );
+
+                case PrivilegeLevel.STANDARD:
+                  return (
+                    <>
+                      <Switch>
+                        <Route path="/" exact component={Landing} />
+                        <Route path="/login">
+                          <Redirect to="/home" />
+                        </Route>
+                        <Route path="/signup">
+                          <Redirect to="/home" />
+                        </Route>
+                        <Route path="/home" exact component={Home} />
+                        <Route path="/settings" exact component={Settings} />
+                        <Route
+                          path="/volunteer"
+                          exact
+                          component={VolunteerLeaderboard}
+                        />
+                        <Route path="/admin">
+                          <Redirect to="/home" />
+                        </Route>
+                        <Route path="*" exact component={NotFound} />
+                      </Switch>
+                    </>
+                  );
+
+                case PrivilegeLevel.ADMIN:
+                  return (
+                    <>
+                      <Switch>
+                        <Route path="/" exact component={Landing} />
+                        <Route path="/login">
+                          <Redirect to="/home" />
+                        </Route>
+                        <Route path="/signup">
+                          <Redirect to="/home" />
+                        </Route>
+                        <Route path="/home" exact component={Home} />
+                        <Route path="/settings" exact component={Settings} />
+                        <Route
+                          path="/volunteer"
+                          exact
+                          component={VolunteerLeaderboard}
+                        />
+                        <Route path="/admin" exact component={AdminDashboard} />
+                        <Route path="*" exact component={NotFound} />
+                      </Switch>
+                    </>
+                  );
+              }
+            })()}
           </Content>
         </Layout>
       </Router>
@@ -48,4 +133,10 @@ const App: React.FC = () => {
   );
 };
 
-export default App;
+const mapStateToProps = (state: C4CState): AppProps => {
+  return {
+    tokens: state.authenticationState.tokens,
+  };
+};
+
+export default connect(mapStateToProps)(App);

--- a/src/auth/ducks/types.ts
+++ b/src/auth/ducks/types.ts
@@ -45,7 +45,7 @@ export interface RefreshTokenResponse {
 }
 
 export enum PrivilegeLevel {
-  NONE = -1,
+  NONE = 'none',
   STANDARD = 'standard',
   ADMIN = 'admin',
 }

--- a/src/auth/ducks/types.ts
+++ b/src/auth/ducks/types.ts
@@ -46,8 +46,8 @@ export interface RefreshTokenResponse {
 
 export enum PrivilegeLevel {
   NONE = -1,
-  STANDARD = 0,
-  ADMIN = 1,
+  STANDARD = 'standard',
+  ADMIN = 'admin',
 }
 
 export const NO_USER_ID = -1;

--- a/src/auth/token.tsx
+++ b/src/auth/token.tsx
@@ -31,7 +31,7 @@ export interface TokenService {
   readonly getRefreshToken: () => string | null;
   readonly setRefreshToken: (token: string) => void;
   readonly removeRefreshToken: () => void;
-  readonly getPrivilegeLevel: () => number | string;
+  readonly getPrivilegeLevel: () => string;
   readonly getUserID: () => number;
   readonly isRefreshTokenValid: () => boolean;
 }
@@ -58,11 +58,12 @@ const tokenService: TokenService = {
   getPrivilegeLevel() {
     try {
       const payload = getTokenPayload(LOCALSTORAGE_TOKEN_KEY.ACCESS);
-      if (!payload) return -1;
-      if (payload.privilegeLevel === 0) return 0;
-      return payload.privilegeLevel || -1;
+      if (!payload) return PrivilegeLevel.NONE;
+      if (payload.privilegeLevel === PrivilegeLevel.STANDARD)
+        return PrivilegeLevel.STANDARD;
+      return payload.privilegeLevel || PrivilegeLevel.NONE;
     } catch (e) {
-      return -1;
+      return PrivilegeLevel.NONE;
     }
   },
   getUserID() {

--- a/src/auth/token.tsx
+++ b/src/auth/token.tsx
@@ -31,7 +31,7 @@ export interface TokenService {
   readonly getRefreshToken: () => string | null;
   readonly setRefreshToken: (token: string) => void;
   readonly removeRefreshToken: () => void;
-  readonly getPrivilegeLevel: () => number;
+  readonly getPrivilegeLevel: () => number | string;
   readonly getUserID: () => number;
   readonly isRefreshTokenValid: () => boolean;
 }


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/1016839076)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Ensures only users with proper privilege levels can see protected pages.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Updated `PrivilegeLevel` and `getPrivilegeLevel()`
- Use switch case to declare routes for each privilege level type
- If the user lacks the appropriate privilege level for a path, redirects using `Redirect`

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Ran frontend and backend locally, tried each path and checked it went to the appropriate place after:
- not logging in
- logging in as a standard user
- logging in as an admin