### PR TITLE
Individual Teams Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,12 +75,26 @@ const App: React.FC = () => {
                       <Route path={Routes.LANDING} exact component={Landing} />
                       <Route path={Routes.LOGIN} exact component={Login} />
                       <Route path={Routes.SIGNUP} exact component={Signup} />
+                      <Route path={Routes.HOME}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
+                      <Route path={Routes.SETTINGS}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
+                      <Route path={Routes.VOLUNTEER}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
+                      <Route path={Routes.TEAM_LEADERBOARD}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
+                      <Route path={Routes.ADMIN}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
                       <Route
                         path={Routes.NOT_FOUND}
                         exact
                         component={NotFound}
                       />
-                      <Redirect to={Routes.LOGIN} />
                     </Switch>
                   );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export enum Routes {
   HOME = '/home',
   SETTINGS = '/settings',
   VOLUNTEER = '/volunteer',
-  TEAM = '/team',
+  TEAM = '/team:id',
   TEAM_LEADERBOARD = '/team-leaderboard',
   ADMIN = '/admin',
   NOT_FOUND = '*',
@@ -75,29 +75,12 @@ const App: React.FC = () => {
                       <Route path={Routes.LANDING} exact component={Landing} />
                       <Route path={Routes.LOGIN} exact component={Login} />
                       <Route path={Routes.SIGNUP} exact component={Signup} />
-                      <Route path={Routes.HOME}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
-                      <Route path={Routes.SETTINGS}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
-                      <Route path={Routes.VOLUNTEER}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
-                      <Route path={Routes.TEAM}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
-                      <Route path={Routes.TEAM_LEADERBOARD}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
-                      <Route path={Routes.ADMIN}>
-                        <Redirect to={Routes.LOGIN} />
-                      </Route>
                       <Route
                         path={Routes.NOT_FOUND}
                         exact
                         component={NotFound}
                       />
+                      <Redirect to={Routes.LOGIN} />
                     </Switch>
                   );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Landing from './containers/landing';
 import AdminDashboard from './containers/adminDashboard';
 import VolunteerLeaderboard from './containers/volunteerLeaderboard';
 import TeamLeaderboard from './containers/teamLeaderboard';
+import TeamPage from './containers/teamPage';
 import { Layout } from 'antd';
 import Home from './containers/home';
 import Signup from './containers/signup';
@@ -42,7 +43,8 @@ export enum Routes {
   HOME = '/home',
   SETTINGS = '/settings',
   VOLUNTEER = '/volunteer',
-  TEAM_LEADERBOARD = './team-leaderboard',
+  TEAM = '/team',
+  TEAM_LEADERBOARD = '/team-leaderboard',
   ADMIN = '/admin',
   NOT_FOUND = '*',
 }
@@ -82,6 +84,9 @@ const App: React.FC = () => {
                       <Route path={Routes.VOLUNTEER}>
                         <Redirect to={Routes.LOGIN} />
                       </Route>
+                      <Route path={Routes.TEAM}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
                       <Route path={Routes.TEAM_LEADERBOARD}>
                         <Redirect to={Routes.LOGIN} />
                       </Route>
@@ -117,6 +122,7 @@ const App: React.FC = () => {
                         exact
                         component={VolunteerLeaderboard}
                       />
+                      <Route path={Routes.TEAM} exact component={TeamPage} />
                       <Route
                         path={Routes.TEAM_LEADERBOARD}
                         exact
@@ -154,6 +160,7 @@ const App: React.FC = () => {
                         exact
                         component={VolunteerLeaderboard}
                       />
+                      <Route path={Routes.TEAM} exact component={TeamPage} />
                       <Route
                         path={Routes.TEAM_LEADERBOARD}
                         exact

--- a/src/components/goalInfo/index.tsx
+++ b/src/components/goalInfo/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Card, Typography } from 'antd';
+import { DARK_GREEN, TEXT_GREY } from '../../utils/colors';
+
+const { Paragraph } = Typography;
+
+interface GoalInfoProps {
+  readonly blockProgress: number;
+  readonly blockGoal: number;
+  readonly startDate: string;
+  readonly targetDate: string;
+}
+
+const CardContainer = styled.div`
+  height: 125px;
+  display: flex;
+  overflow-x: scroll;
+  overflow-y: hidden;
+`;
+
+const RightMargin = styled.div`
+  margin-right: 10px;
+`;
+
+const StyledCard = styled(Card)`
+  min-width: 200px;
+  max-width: 300px;
+  height: 125px;
+  display: inline-block;
+  border-radius: 2px;
+`;
+
+const CardHeader = styled(Paragraph)`
+  font-size: 14px;
+  line-height: 1;
+  color: ${TEXT_GREY};
+`;
+
+const LargeText = styled(Paragraph)`
+  display: inline-block;
+  font-size: 25px;
+  color: ${DARK_GREEN};
+`;
+
+const SmallText = styled(Paragraph)`
+  display: inline-block;
+  font-size: 15px;
+  color: ${DARK_GREEN};
+`;
+
+const GoalInfo: React.FC<GoalInfoProps> = ({
+  blockProgress,
+  blockGoal,
+  startDate,
+  targetDate,
+}) => {
+  return (
+    <CardContainer>
+      <RightMargin>
+        <StyledCard>
+          <CardHeader>Blocks Counted</CardHeader>
+          <SmallText>
+            <LargeText>{blockProgress}</LargeText>/{blockGoal}
+          </SmallText>
+        </StyledCard>
+      </RightMargin>
+      <RightMargin>
+        <StyledCard>
+          <CardHeader>Start Date</CardHeader>
+          <LargeText>{startDate}</LargeText>
+        </StyledCard>
+      </RightMargin>
+      <StyledCard>
+        <CardHeader>Target Date</CardHeader>
+        <LargeText>{targetDate}</LargeText>
+      </StyledCard>
+    </CardContainer>
+  );
+};
+
+export default GoalInfo;

--- a/src/components/landingTreeStats/index.tsx
+++ b/src/components/landingTreeStats/index.tsx
@@ -5,6 +5,7 @@ import useWindowDimensions, { WindowTypes } from '../window-dimensions';
 import { TEXT_GREY, MID_GREEN } from '../../utils/colors';
 import MobileInfoCard from '../mobileComponents/mobileInfoCard';
 import InfoCard from '../infoCard';
+import { getMoneyString } from '../../utils/stringFormat';
 
 const TreeStatsContainer = styled.div`
   margin-top: 35px;
@@ -130,15 +131,5 @@ const LandingTreeStats: React.FC<LandingTreeStatsProps> = ({
       );
   }
 };
-
-// TODO: Move function to a common utilities file
-
-/**
- * Converts the given dollar amount to a formatted string
- * @param amount the amount to convert
- */
-export function getMoneyString(amount: number): string {
-  return `$${amount.toLocaleString('en-us', { maximumFractionDigits: 2 })}`;
-}
 
 export default LandingTreeStats;

--- a/src/components/teamMember/index.tsx
+++ b/src/components/teamMember/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import { List, Typography } from 'antd';
+import { CrownOutlined } from '@ant-design/icons';
+import { BLACK, LIGHT_GREEN } from '../../utils/colors';
+import { TeamRole } from '../../containers/teamPage/ducks/types';
+
+const { Paragraph } = Typography;
+
+const StyledListItem = styled(List.Item)`
+  margin-bottom: 10px;
+  width: 85%;
+  height: 40px;
+  background: ${LIGHT_GREEN}90;
+  border: solid 1px ${LIGHT_GREEN}90;
+  border-radius: 2px;
+  padding: 3px 20px;
+`;
+
+const MemberName = styled(Paragraph)`
+  display: inline-block;
+  font-size: 15px;
+  line-height: 32px;
+  color: ${BLACK};
+`;
+
+const StyledCrown = styled(CrownOutlined)`
+  display: inline-block;
+  margin-right: 5px;
+  font-size: 20px;
+  color: ${BLACK};
+`;
+
+interface TeamMemberProps {
+  readonly id: number;
+  readonly team_role: TeamRole;
+  readonly username: string;
+}
+
+const TeamMember: React.FC<TeamMemberProps> = ({ id, team_role, username }) => {
+  return (
+    <StyledListItem key={id} style={{ borderBottom: '0px' }}>
+      {team_role === TeamRole.LEADER && <StyledCrown />}
+      <MemberName>{username}</MemberName>
+    </StyledListItem>
+  );
+};
+
+export default TeamMember;

--- a/src/components/test/landing-tree-stats.test.tsx
+++ b/src/components/test/landing-tree-stats.test.tsx
@@ -1,7 +1,0 @@
-import { getMoneyString } from '../landingTreeStats';
-
-test('getMoneyString tests', () => {
-  expect(getMoneyString(100000)).toBe('$100,000');
-
-  expect(getMoneyString(123456.789)).toBe('$123,456.79');
-});

--- a/src/containers/teamPage/ducks/types.ts
+++ b/src/containers/teamPage/ducks/types.ts
@@ -1,0 +1,29 @@
+export interface TeamProps {
+  id: number;
+  name: string;
+  bio: string;
+  members: MemberProps[];
+  goals: GoalProps[];
+}
+
+export interface MemberProps {
+  user_id: number;
+  username: string;
+  team_role: TeamRole;
+}
+
+export interface GoalProps {
+  id: number;
+  goal: number;
+  progress: number;
+  start_date: Date;
+  complete_by: Date;
+  completion_date: Date | null;
+}
+
+export enum TeamRole {
+  NONE = 'none',
+  MEMBER = 'member',
+  LEADER = 'leader',
+  PENDING = 'pending',
+}

--- a/src/containers/teamPage/index.tsx
+++ b/src/containers/teamPage/index.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, Collapse, List, Typography } from 'antd';
+import { Routes } from '../../App';
+import { GoalProps, MemberProps, TeamProps, TeamRole } from './ducks/types';
+import GoalInfo from '../../components/goalInfo';
+import PageHeader from '../../components/pageHeader';
+import TeamMember from '../../components/teamMember';
+import { LinkButton } from '../../components/LinkButton';
+import { getDateString } from '../../utils/stringFormat';
+import {
+  BLACK,
+  DARK_GREEN,
+  LIGHT_GREEN,
+  MID_GREEN,
+  WHITE,
+} from '../../utils/colors';
+
+const { Paragraph } = Typography;
+const { Panel } = Collapse;
+
+const TeamContainer = styled.div`
+  padding: 70px 134px;
+`;
+
+const StyledLinkButton = styled(LinkButton)`
+  width: 190px;
+  height: 45px;
+  margin-bottom: 20px;
+  border-color: ${MID_GREEN};
+  font-size: 18px;
+  color: ${MID_GREEN};
+`;
+
+const TeamHeaderContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 80px;
+`;
+
+const PageHeaderContainer = styled.div`
+  max-width: 600px;
+`;
+
+const JoinButton = styled(Button)`
+  width: 125px;
+  height: 45px;
+  color: ${WHITE};
+  background-color: ${MID_GREEN};
+  font-size: 18px;
+`;
+
+const CenterDiv = styled.div`
+  margin-top: -50px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const MemberContainer = styled.div`
+  width: 45%;
+`;
+
+const GoalContainer = styled.div`
+  width: 55%;
+`;
+
+const SectionHeader = styled(Paragraph)`
+  font-size: 25px;
+  font-weight: bold;
+  line-height: 1;
+  color: ${DARK_GREEN};
+`;
+
+const StyledMemberList = styled(List)`
+  border-bottom: 0px;
+`;
+
+const LeaderboardCollapse = styled(Collapse)`
+  color: ${BLACK};
+  font-size: 15px;
+`;
+
+const BlackText = styled(Paragraph)`
+  display: inline-block;
+  color: ${BLACK};
+  font-size: 15px;
+  line-height: 0.5;
+`;
+
+const StyledPanel = styled(Panel)`
+  min-height: 40px;
+  margin-bottom: 10px;
+  padding-left: 10px;
+  background-color: ${LIGHT_GREEN}90;
+  border: 0px;
+`;
+
+const Line = styled.div`
+  height: 1px;
+  width: 104%;
+  margin: 0px -10px 10px -20px;
+  display: block;
+  background-color: ${WHITE};
+`;
+
+// dummy data
+const sampleMemberData: MemberProps[] = [
+  {
+    user_id: 1,
+    username: 'florisdobber',
+    team_role: TeamRole.LEADER,
+  },
+  {
+    user_id: 2,
+    username: 'jackblanc',
+    team_role: TeamRole.MEMBER,
+  },
+  {
+    user_id: 3,
+    username: 'atreecounter',
+    team_role: TeamRole.NONE,
+  },
+  {
+    user_id: 4,
+    username: 'speakerofthetrees',
+    team_role: TeamRole.PENDING,
+  },
+  {
+    user_id: 5,
+    username: 'vrushalitarte01',
+    team_role: TeamRole.MEMBER,
+  },
+  {
+    user_id: 6,
+    username: 'willmt80',
+    team_role: TeamRole.MEMBER,
+  },
+  {
+    user_id: 7,
+    username: 'apradhan12',
+    team_role: TeamRole.MEMBER,
+  },
+  {
+    user_id: 8,
+    username: 'SofieDunt',
+    team_role: TeamRole.MEMBER,
+  },
+];
+
+const sampleGoalData: GoalProps[] = [
+  {
+    id: 1,
+    goal: 50,
+    progress: 5,
+    start_date: new Date(2021, 0, 1),
+    complete_by: new Date(2022, 0, 1),
+    completion_date: null,
+  },
+  {
+    id: 2,
+    goal: 500,
+    progress: 71,
+    start_date: new Date(2021, 2, 20),
+    complete_by: new Date(2021, 4, 21),
+    completion_date: null,
+  },
+  {
+    id: 3,
+    goal: 10,
+    progress: 10,
+    start_date: new Date(2020, 5, 10),
+    complete_by: new Date(2020, 7, 10),
+    completion_date: new Date(2020, 6, 13),
+  },
+];
+
+const sampleTeamData: TeamProps = {
+  id: 1,
+  name: 'Code4Community',
+  bio: 'Short description about how cool of a team Code4Community is!',
+  members: sampleMemberData,
+  goals: sampleGoalData,
+};
+
+const TeamPage: React.FC = () => {
+  const onClick = () => {
+    // TODO: join team
+  };
+
+  return (
+    <TeamContainer>
+      <StyledLinkButton to={Routes.LOGIN}>
+        {`<`} Return to Teams
+      </StyledLinkButton>
+      <TeamHeaderContainer>
+        <PageHeaderContainer>
+          <PageHeader
+            pageTitle={sampleTeamData.name}
+            pageSubtitle={sampleTeamData.bio}
+          />
+        </PageHeaderContainer>
+        <JoinButton type="primary" onClick={onClick}>
+          Join Team
+        </JoinButton>
+      </TeamHeaderContainer>
+
+      <CenterDiv>
+        <MemberContainer>
+          <SectionHeader>TEAM MEMBERS</SectionHeader>
+          <StyledMemberList
+            dataSource={sampleTeamData.members}
+            itemLayout="vertical"
+          >
+            {sampleTeamData.members.map((member) => {
+              if (
+                member.team_role === TeamRole.LEADER ||
+                member.team_role === TeamRole.MEMBER
+              ) {
+                return (
+                  <TeamMember
+                    id={member.user_id}
+                    team_role={member.team_role}
+                    username={member.username}
+                  />
+                );
+              }
+            })}
+          </StyledMemberList>
+        </MemberContainer>
+        <GoalContainer>
+          <SectionHeader>TEAM GOALS</SectionHeader>
+          <LeaderboardCollapse
+            bordered={false}
+            key={1}
+            defaultActiveKey={sampleTeamData.goals[0].id}
+            expandIconPosition={'right'}
+          >
+            {sampleTeamData.goals.map((item) => {
+              return (
+                <StyledPanel
+                  key={item.id}
+                  header={<BlackText>Goal {item.id}</BlackText>}
+                  extra={
+                    item.completion_date == null && (
+                      <BlackText>Incomplete</BlackText>
+                    )
+                  }
+                >
+                  <Line />
+                  <GoalInfo
+                    blockProgress={item.progress}
+                    blockGoal={item.goal}
+                    startDate={getDateString(item.start_date)}
+                    targetDate={getDateString(item.complete_by)}
+                  />
+                </StyledPanel>
+              );
+            })}
+          </LeaderboardCollapse>
+        </GoalContainer>
+      </CenterDiv>
+    </TeamContainer>
+  );
+};
+
+export default TeamPage;

--- a/src/containers/teamPage/index.tsx
+++ b/src/containers/teamPage/index.tsx
@@ -233,7 +233,6 @@ const TeamPage: React.FC = () => {
           <SectionHeader>TEAM GOALS</SectionHeader>
           <LeaderboardCollapse
             bordered={false}
-            key={1}
             defaultActiveKey={sampleTeamData.goals[0].id}
             expandIconPosition={'right'}
           >

--- a/src/containers/teamPage/index.tsx
+++ b/src/containers/teamPage/index.tsx
@@ -225,6 +225,7 @@ const TeamPage: React.FC = () => {
                   />
                 );
               }
+              return <></>;
             })}
           </StyledMemberList>
         </MemberContainer>

--- a/src/containers/teamPage/index.tsx
+++ b/src/containers/teamPage/index.tsx
@@ -190,7 +190,7 @@ const TeamPage: React.FC = () => {
 
   return (
     <TeamContainer>
-      <StyledLinkButton to={Routes.LOGIN}>
+      <StyledLinkButton to={Routes.AVAILABLE_TEAMS}>
         {`<`} Return to Teams
       </StyledLinkButton>
       <TeamHeaderContainer>

--- a/src/utils/stringFormat.tsx
+++ b/src/utils/stringFormat.tsx
@@ -1,0 +1,15 @@
+/**
+ * Converts the given dollar amount to a formatted string
+ * @param amount the amount to convert
+ */
+export function getMoneyString(amount: number): string {
+  return `$${amount.toLocaleString('en-us', { maximumFractionDigits: 2 })}`;
+}
+
+/**
+ * Converts the given date to a formatted string
+ * @param date the date to convert
+ */
+export function getDateString(date: Date): string {
+  return `${new Intl.DateTimeFormat('en-US').format(date)}`;
+}

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -1,0 +1,12 @@
+import { getMoneyString } from '../stringFormat';
+import { getDateString } from '../stringFormat';
+
+test('getMoneyString tests', () => {
+  expect(getMoneyString(100000)).toBe('$100,000');
+  expect(getMoneyString(123456.789)).toBe('$123,456.79');
+});
+
+test('getDateString tests', () => {
+  expect(getDateString(new Date(2020, 5, 10))).toBe('6/10/2020');
+  expect(getDateString(new Date(2025, 11, 21))).toBe('12/21/2025');
+});


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/926124580)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Creates the team page where users can view a team's members and goals and apply to join.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Created a `types.ts` to match backend
- Created `TeamPage` container, which uses a list to display all members in the team and a collapse to display goals
  - info about members (username, role) is formatted in `TeamMember` component
    - team leader has a crown next to their username
  - expanding a collapse panel shows info about the goal, which is formatted in `GoalInfo` component
  - the first goal in the data is expanded by default
  - "Incomplete" is displayed by the collapse panel's dropdown if the goal's `completion_date` is `null`
- Added route for individual team page
- Created `getDateString` to format dates as a string, moved it to `utils/stringFormat.tsx` with `getMoneyString` (and tests)
- "Return to Teams" button currently redirects to login page, should be changed after teams page is added

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
<img width="1680" alt="IndividualTeamPage" src="https://user-images.githubusercontent.com/22990100/109408643-5466b700-7959-11eb-90d5-b67d4fe69917.png">
<img width="1680" alt="OpenAllGoals" src="https://user-images.githubusercontent.com/22990100/109408644-56c91100-7959-11eb-95e4-e5e66eaff60c.png">

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Used dummy data, visually confirmed data was displayed correctly and page matched designs