### PR TITLE
created available teams page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Landing from './containers/landing';
 import AdminDashboard from './containers/adminDashboard';
 import VolunteerLeaderboard from './containers/volunteerLeaderboard';
 import TeamLeaderboard from './containers/teamLeaderboard';
+import AvailableTeams from './containers/availableTeams';
 import { Layout } from 'antd';
 import Home from './containers/home';
 import Signup from './containers/signup';
@@ -44,6 +45,7 @@ export enum Routes {
   VOLUNTEER = '/volunteer',
   TEAM_LEADERBOARD = '/team-leaderboard',
   ADMIN = '/admin',
+  AVAILABLE_TEAMS = '/available',
   NOT_FOUND = '*',
 }
 
@@ -85,6 +87,9 @@ const App: React.FC = () => {
                       <Route path={Routes.TEAM_LEADERBOARD}>
                         <Redirect to={Routes.LOGIN} />
                       </Route>
+                      <Route path={Routes.AVAILABLE_TEAMS}>
+                        <Redirect to={Routes.LOGIN} />
+                      </Route>
                       <Route path={Routes.ADMIN}>
                         <Redirect to={Routes.LOGIN} />
                       </Route>
@@ -122,6 +127,11 @@ const App: React.FC = () => {
                         exact
                         component={TeamLeaderboard}
                       />
+                      <Route
+                        path={Routes.AVAILABLE_TEAMS}
+                        exact
+                        component={AvailableTeams}
+                      />
                       <Route path={Routes.ADMIN}>
                         <Redirect to={Routes.HOME} />
                       </Route>
@@ -158,6 +168,11 @@ const App: React.FC = () => {
                         path={Routes.TEAM_LEADERBOARD}
                         exact
                         component={TeamLeaderboard}
+                      />
+                      <Route
+                        path={Routes.AVAILABLE_TEAMS}
+                        exact
+                        component={AvailableTeams}
                       />
                       <Route
                         path={Routes.ADMIN}

--- a/src/components/leaderboard/leaderboardSpace/index.tsx
+++ b/src/components/leaderboard/leaderboardSpace/index.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { ParagraphProps } from 'antd/lib/typography/Paragraph';
+import { SpaceProps } from 'antd/lib/space/index';
+import { BLACK, LIGHT_GREEN } from '../../../utils/colors';
+import styled from 'styled-components';
+import { Collapse, Space, Typography } from 'antd';
+
+const { Panel } = Collapse;
+const { Paragraph } = Typography;
+
+interface LeaderboardStyleProps {
+  large?: boolean;
+}
+
+const LeaderboardSpace = styled(Space)<SpaceProps>`
+  width: 100%;
+`;
+
+const LeaderboardCollapse = styled(Collapse)`
+  background-color: ${LIGHT_GREEN}80;
+  border-radius: 0px;
+  ${(props: LeaderboardStyleProps) => props.large && 'padding: 15px 0px 10px'};
+`;
+
+const LeaderboardItemName = styled(Paragraph)`
+  color: ${BLACK};
+  display: inline-block;
+  line-height: 0px;
+  ${(props: LeaderboardStyleProps) => props.large && 'font-size: 20px'};
+`;
+
+const LeaderboardRankContainer = styled.span`
+  width: 50px;
+  display: inline-block;
+`;
+
+const LeaderboardItemRank = styled(Paragraph)<ParagraphProps>`
+  color: ${BLACK};
+  display: inline;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 20px;
+  line-height: 0px;
+`;
+
+export interface TabItem {
+  rank?: number;
+  id: number;
+  name: string; // for now, these are assumed to be unique
+  rightSide: React.ReactNode;
+  collapseContent?: React.ReactNode;
+}
+
+interface LeaderboardSpaceProps {
+  tabItems: TabItem[];
+  currentPage: number;
+  itemsPerPage: number;
+  activePanelKey?: number;
+  large?: boolean;
+}
+
+const LeaderboardPanels: React.FC<LeaderboardSpaceProps> = ({
+  tabItems,
+  currentPage,
+  itemsPerPage,
+  large,
+}) => {
+  const itemsOnPage = tabItems.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
+
+  return (
+    <LeaderboardSpace direction="vertical" size={large ? 22 : 'small'}>
+      {itemsOnPage.map((item) => {
+        return (
+          <LeaderboardCollapse bordered={true} key={item.name} large={large}>
+            <Panel
+              key={item.name}
+              header={
+                <>
+                  <LeaderboardRankContainer>
+                    <LeaderboardItemRank>
+                      {item.rank && item.rank}
+                    </LeaderboardItemRank>
+                  </LeaderboardRankContainer>
+                  <LeaderboardItemName large={large}>
+                    {item.name}
+                  </LeaderboardItemName>
+                </>
+              }
+              extra={item.rightSide}
+              showArrow={false}
+              disabled={!item.collapseContent}
+            >
+              {item.collapseContent}
+            </Panel>
+          </LeaderboardCollapse>
+        );
+      })}
+    </LeaderboardSpace>
+  );
+};
+
+export default LeaderboardPanels;

--- a/src/components/leaderboard/leaderboardSpace/index.tsx
+++ b/src/components/leaderboard/leaderboardSpace/index.tsx
@@ -4,6 +4,7 @@ import { SpaceProps } from 'antd/lib/space/index';
 import { BLACK, LIGHT_GREEN } from '../../../utils/colors';
 import styled from 'styled-components';
 import { Collapse, Space, Typography } from 'antd';
+import { TabItem } from '../types';
 
 const { Panel } = Collapse;
 const { Paragraph } = Typography;
@@ -26,7 +27,8 @@ const LeaderboardItemName = styled(Paragraph)`
   color: ${BLACK};
   display: inline-block;
   line-height: 0px;
-  ${(props: LeaderboardStyleProps) => props.large && 'font-size: 20px; font-weight: bold;'};
+  ${({ large }: LeaderboardStyleProps) =>
+    large && 'font-size: 20px; font-weight: bold;'};
 `;
 
 const LeaderboardRankContainer = styled.span`
@@ -43,14 +45,6 @@ const LeaderboardItemRank = styled(Paragraph)<ParagraphProps>`
   line-height: 0px;
 `;
 
-export interface TabItem {
-  rank?: number;
-  id: number;
-  name: string; // for now, these are assumed to be unique
-  rightSide: React.ReactNode;
-  collapseContent?: React.ReactNode;
-}
-
 interface LeaderboardSpaceProps {
   tabItems: TabItem[];
   currentPage: number;
@@ -65,39 +59,37 @@ const LeaderboardPanels: React.FC<LeaderboardSpaceProps> = ({
   itemsPerPage,
   large,
 }) => {
-  const itemsOnPage = tabItems.slice(
+  const itemsOnPage: TabItem[] = tabItems.slice(
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage,
   );
 
   return (
-    <LeaderboardSpace direction="vertical" size={large ? 22 : 'small'}>
-      {itemsOnPage.map((item) => {
-        return (
-          <LeaderboardCollapse bordered={true} key={item.name} large={large}>
-            <Panel
-              key={item.name}
-              header={
-                <>
-                  <LeaderboardRankContainer>
-                    <LeaderboardItemRank>
-                      {item.rank && item.rank}
-                    </LeaderboardItemRank>
-                  </LeaderboardRankContainer>
-                  <LeaderboardItemName large={large}>
-                    {item.name}
-                  </LeaderboardItemName>
-                </>
-              }
-              extra={item.rightSide}
-              showArrow={false}
-              disabled={!item.collapseContent}
-            >
-              {item.collapseContent}
-            </Panel>
-          </LeaderboardCollapse>
-        );
-      })}
+    <LeaderboardSpace direction="vertical" size={large ? 'large' : 'small'}>
+      {itemsOnPage.map((item) => (
+        <LeaderboardCollapse bordered={true} key={item.name} large={large}>
+          <Panel
+            key={item.id}
+            header={
+              <>
+                <LeaderboardRankContainer>
+                  <LeaderboardItemRank>
+                    {item.rank && item.rank}
+                  </LeaderboardItemRank>
+                </LeaderboardRankContainer>
+                <LeaderboardItemName large={large}>
+                  {item.name}
+                </LeaderboardItemName>
+              </>
+            }
+            extra={item.rightSide}
+            showArrow={false}
+            disabled={!item.collapseContent}
+          >
+            {item.collapseContent}
+          </Panel>
+        </LeaderboardCollapse>
+      ))}
     </LeaderboardSpace>
   );
 };

--- a/src/components/leaderboard/leaderboardSpace/index.tsx
+++ b/src/components/leaderboard/leaderboardSpace/index.tsx
@@ -26,7 +26,7 @@ const LeaderboardItemName = styled(Paragraph)`
   color: ${BLACK};
   display: inline-block;
   line-height: 0px;
-  ${(props: LeaderboardStyleProps) => props.large && 'font-size: 20px'};
+  ${(props: LeaderboardStyleProps) => props.large && 'font-size: 20px; font-weight: bold;'};
 `;
 
 const LeaderboardRankContainer = styled.span`

--- a/src/components/leaderboard/leaderboardTab/index.tsx
+++ b/src/components/leaderboard/leaderboardTab/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Col, Row } from 'antd';
-import LeaderboardPanels, { TabItem } from '../leaderboardSpace';
+import LeaderboardPanels from '../leaderboardSpace';
+import { TabItem } from '../types';
 
 interface LeaderboardTabProps {
   tabItems: TabItem[];

--- a/src/components/leaderboard/leaderboardTab/index.tsx
+++ b/src/components/leaderboard/leaderboardTab/index.tsx
@@ -1,45 +1,6 @@
 import * as React from 'react';
-import { Collapse, Space, Typography, Col, Row } from 'antd';
-import { ParagraphProps } from 'antd/lib/typography/Paragraph';
-import { CollapseProps } from 'antd/lib/collapse/Collapse';
-import { SpaceProps } from 'antd/lib/space/index';
-import { BLACK, LIGHT_GREEN } from '../../../utils/colors';
-import styled from 'styled-components';
-
-const { Paragraph } = Typography;
-const { Panel } = Collapse;
-
-const LeaderBoardItemHeader = styled.span`
-  text-align: center;
-`;
-
-const LeaderboardSpace = styled(Space)<SpaceProps>`
-  width: 100%;
-`;
-
-const LeaderboardCollapse = styled(Collapse)<CollapseProps>`
-  background-color: ${LIGHT_GREEN}80;
-  border-radius: 0px;
-`;
-
-const LeaderboardItemName = styled(Paragraph)<ParagraphProps>`
-  color: ${BLACK};
-  display: inline;
-  position: absolute;
-  left: 57px;
-  top: 19px;
-  vertical-align: middle;
-  line-height: 0px;
-`;
-
-const LeaderboardItemRank = styled(Paragraph)<ParagraphProps>`
-  color: ${BLACK};
-  display: inline;
-  padding-right: 20px;
-  vertical-align: middle;
-  font-size: 20px;
-  line-height: 0px;
-`;
+import { Col, Row } from 'antd';
+import LeaderboardPanels, { TabItem } from '../leaderboardSpace';
 
 interface LeaderboardTabProps {
   tabItems: TabItem[];
@@ -48,55 +9,21 @@ interface LeaderboardTabProps {
   activePanelKey?: number;
 }
 
-export interface TabItem {
-  rank?: number;
-  id: number;
-  name: string; // for now, these are assumed to be unique
-  rightSide: React.ReactNode;
-  collapseContent?: React.ReactNode;
-}
-
 const LeaderboardTab: React.FC<LeaderboardTabProps> = ({
   tabItems,
   currentPage,
   itemsPerPage,
 }) => {
-  const itemsOnPage = tabItems.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage,
-  );
-
   return (
     <>
       <Row>
         <Col span={8}>The card</Col>
         <Col span={16}>
-          {
-            <LeaderboardSpace direction="vertical">
-              {itemsOnPage.map((item) => {
-                return (
-                  <LeaderboardCollapse bordered={true} key={item.name}>
-                    <Panel
-                      key={item.name}
-                      header={
-                        <LeaderBoardItemHeader>
-                          <LeaderboardItemRank>
-                            {item.rank && item.rank}
-                          </LeaderboardItemRank>
-                          <LeaderboardItemName>{item.name}</LeaderboardItemName>
-                        </LeaderBoardItemHeader>
-                      }
-                      extra={item.rightSide}
-                      showArrow={false}
-                      disabled={!item.collapseContent}
-                    >
-                      {item.collapseContent}
-                    </Panel>
-                  </LeaderboardCollapse>
-                );
-              })}
-            </LeaderboardSpace>
-          }
+          <LeaderboardPanels
+            tabItems={tabItems}
+            currentPage={currentPage}
+            itemsPerPage={itemsPerPage}
+          />
         </Col>
       </Row>
     </>

--- a/src/components/leaderboard/leaderboardTabs/index.tsx
+++ b/src/components/leaderboard/leaderboardTabs/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Tabs, Pagination } from 'antd';
-import LeaderboardTab, { TabItem } from '../leaderboardTab';
+import LeaderboardTab from '../leaderboardTab';
+import { TabItem } from '../leaderboardSpace';
 import { tabToDays } from '../constants';
 
 export interface TabInfo {

--- a/src/components/leaderboard/leaderboardTabs/index.tsx
+++ b/src/components/leaderboard/leaderboardTabs/index.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 import { Tabs, Pagination } from 'antd';
 import LeaderboardTab from '../leaderboardTab';
-import { TabItem } from '../leaderboardSpace';
+import { TabItem } from '../types';
 import { tabToDays } from '../constants';
-
-export interface TabInfo {
-  name: string;
-  content: TabItem[];
-}
 
 interface LeaderboardTabsProps {
   items: TabItem[];

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -1,0 +1,7 @@
+export interface TabItem {
+  rank?: number;
+  id: number;
+  name: string;
+  rightSide: React.ReactNode;
+  collapseContent?: React.ReactNode;
+}

--- a/src/components/linkCarousel/index.tsx
+++ b/src/components/linkCarousel/index.tsx
@@ -55,7 +55,7 @@ const LinkCarousel: React.FC = () => {
         <CarouselSlide>
           <LinkCard
             text="View Teams"
-            path={Routes.NOT_FOUND}
+            path={Routes.AVAILABLE_TEAMS}
             background="img2"
           />
         </CarouselSlide>

--- a/src/containers/availableTeams/index.tsx
+++ b/src/containers/availableTeams/index.tsx
@@ -26,13 +26,18 @@ const TeamDivider = styled(Divider)`
   margin-bottom: 20px;
 `;
 
+const ArrowLink = styled(ArrowRightOutlined)`
+  line-height: 0px;
+  font-size: 20px;
+`;
+
 const dummy: TabItem[] = [
   {
     id: 1,
     name: 'team1',
     rightSide: (
       <Button type="text">
-        <ArrowRightOutlined />
+        <ArrowLink />
       </Button>
     ),
   },
@@ -41,7 +46,7 @@ const dummy: TabItem[] = [
     name: 'team2',
     rightSide: (
       <Button type="text">
-        <ArrowRightOutlined />
+        <ArrowLink />
       </Button>
     ),
   },
@@ -50,7 +55,7 @@ const dummy: TabItem[] = [
     name: 'team3',
     rightSide: (
       <Button type="text">
-        <ArrowRightOutlined />
+        <ArrowLink/>
       </Button>
     ),
   },

--- a/src/containers/availableTeams/index.tsx
+++ b/src/containers/availableTeams/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import LeaderboardSpace, {
-  TabItem,
-} from '../../components/leaderboard/leaderboardSpace';
+import LeaderboardSpace from '../../components/leaderboard/leaderboardSpace';
+import { TabItem } from '../../components/leaderboard/types';
 import { Pagination, Divider } from 'antd';
 import PageHeader from '../../components/pageHeader';
 import styled from 'styled-components';
@@ -55,7 +54,7 @@ const dummy: TabItem[] = [
     name: 'team3',
     rightSide: (
       <Button type="text">
-        <ArrowLink/>
+        <ArrowLink />
       </Button>
     ),
   },

--- a/src/containers/availableTeams/index.tsx
+++ b/src/containers/availableTeams/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import LeaderboardSpace, {
+  TabItem,
+} from '../../components/leaderboard/leaderboardSpace';
+import { Pagination, Divider } from 'antd';
+import PageHeader from '../../components/pageHeader';
+import styled from 'styled-components';
+import { Button } from 'antd';
+import { ArrowRightOutlined } from '@ant-design/icons';
+
+const ContentContainer = styled.div`
+  padding: 100px 134px;
+`;
+
+const TeamsContainer = styled.div`
+  margin: 80px 0px 40px;
+`;
+
+const TeamPagination = styled(Pagination)`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const TeamDivider = styled(Divider)`
+  margin-top: 10px;
+  margin-bottom: 20px;
+`;
+
+const dummy: TabItem[] = [
+  {
+    id: 1,
+    name: 'team1',
+    rightSide: (
+      <Button type="text">
+        <ArrowRightOutlined />
+      </Button>
+    ),
+  },
+  {
+    id: 2,
+    name: 'team2',
+    rightSide: (
+      <Button type="text">
+        <ArrowRightOutlined />
+      </Button>
+    ),
+  },
+  {
+    id: 3,
+    name: 'team3',
+    rightSide: (
+      <Button type="text">
+        <ArrowRightOutlined />
+      </Button>
+    ),
+  },
+];
+
+const AvailableTeams: React.FC = () => {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  return (
+    <ContentContainer>
+      <PageHeader
+        pageTitle="Available Teams"
+        pageSubtitle="Take a peak at the teams accepting new members!"
+      />
+
+      <TeamsContainer>
+        <TeamPagination
+          showSizeChanger={false}
+          current={currentPage}
+          onChange={setCurrentPage}
+          total={50}
+        />
+        <TeamDivider />
+        <LeaderboardSpace
+          tabItems={dummy}
+          itemsPerPage={2}
+          currentPage={currentPage}
+          large
+        />
+      </TeamsContainer>
+    </ContentContainer>
+  );
+};
+
+export default AvailableTeams;

--- a/src/containers/teamLeaderboard/ducks/selectors.ts
+++ b/src/containers/teamLeaderboard/ducks/selectors.ts
@@ -1,6 +1,6 @@
 import { AsyncRequest, AsyncRequestKinds } from '../../../utils/asyncRequest';
 import { TeamLeaderboardItem } from './types';
-import { TabItem } from '../../../components/leaderboard/leaderboardTab';
+import { TabItem } from '../../../components/leaderboard/leaderboardSpace';
 
 export const mapTeamsToTabItems = (
   items: AsyncRequest<TeamLeaderboardItem[], any>,

--- a/src/containers/teamLeaderboard/ducks/selectors.ts
+++ b/src/containers/teamLeaderboard/ducks/selectors.ts
@@ -1,6 +1,6 @@
 import { AsyncRequest, AsyncRequestKinds } from '../../../utils/asyncRequest';
 import { TeamLeaderboardItem } from './types';
-import { TabItem } from '../../../components/leaderboard/leaderboardSpace';
+import { TabItem } from '../../../components/leaderboard/types';
 
 export const mapTeamsToTabItems = (
   items: AsyncRequest<TeamLeaderboardItem[], any>,

--- a/src/containers/teamLeaderboard/index.tsx
+++ b/src/containers/teamLeaderboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import LeaderboardTabs from '../../components/leaderboard/leaderboardTabs';
-import { TabItem } from '../../components/leaderboard/leaderboardSpace';
+import { TabItem } from '../../components/leaderboard/types';
 import { C4CState } from '../../store';
 import PageHeader from '../../components/pageHeader';
 import styled from 'styled-components';

--- a/src/containers/teamLeaderboard/index.tsx
+++ b/src/containers/teamLeaderboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import LeaderboardTabs from '../../components/leaderboard/leaderboardTabs';
-import { TabItem } from '../../components/leaderboard/leaderboardTab';
+import { TabItem } from '../../components/leaderboard/leaderboardSpace';
 import { C4CState } from '../../store';
 import PageHeader from '../../components/pageHeader';
 import styled from 'styled-components';

--- a/src/containers/volunteerLeaderboard/ducks/selectors.ts
+++ b/src/containers/volunteerLeaderboard/ducks/selectors.ts
@@ -1,6 +1,6 @@
 import { AsyncRequest, AsyncRequestKinds } from '../../../utils/asyncRequest';
 import { VolunteerLeaderboardItem } from './types';
-import { TabItem } from '../../../components/leaderboard/leaderboardTab';
+import { TabItem } from '../../../components/leaderboard/leaderboardSpace';
 
 export const mapVolunteersToTabItems = (
   items: AsyncRequest<VolunteerLeaderboardItem[], any>,

--- a/src/containers/volunteerLeaderboard/ducks/selectors.ts
+++ b/src/containers/volunteerLeaderboard/ducks/selectors.ts
@@ -1,6 +1,6 @@
 import { AsyncRequest, AsyncRequestKinds } from '../../../utils/asyncRequest';
 import { VolunteerLeaderboardItem } from './types';
-import { TabItem } from '../../../components/leaderboard/leaderboardSpace';
+import { TabItem } from '../../../components/leaderboard/types';
 
 export const mapVolunteersToTabItems = (
   items: AsyncRequest<VolunteerLeaderboardItem[], any>,

--- a/src/containers/volunteerLeaderboard/index.tsx
+++ b/src/containers/volunteerLeaderboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import LeaderboardTabs from '../../components/leaderboard/leaderboardTabs';
-import { TabItem } from '../../components/leaderboard/leaderboardSpace';
+import { TabItem } from '../../components/leaderboard/types';
 import { C4CState } from '../../store';
 import PageHeader from '../../components/pageHeader';
 import styled from 'styled-components';

--- a/src/containers/volunteerLeaderboard/index.tsx
+++ b/src/containers/volunteerLeaderboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import LeaderboardTabs from '../../components/leaderboard/leaderboardTabs';
-import { TabItem } from '../../components/leaderboard/leaderboardTab';
+import { TabItem } from '../../components/leaderboard/leaderboardSpace';
 import { C4CState } from '../../store';
 import PageHeader from '../../components/pageHeader';
 import styled from 'styled-components';


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/926124762)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

This PR allows users to view which teams are accepting new people and allows the user to click a button to view the pages of those teams

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Created an `AvailableTeams` component which has a header, pagination, and the collapse with the teams

Moved a part of `LeaderboardTabs` to its own component, `LeaderboardSpace` as the main section of the page in order to reuse some of the logic for a paginated leaderboard. Added an optional `large` prop which is a boolean that sets the size of the leaderboard items.

There is an empty button on each team item right now which will eventually be a link to the individual team page

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![Capture](https://user-images.githubusercontent.com/19194912/109570320-d836b580-7ab7-11eb-9316-9d3b405b75f6.PNG)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

Used dummy data to verify that the styling was correct. Used dummy data for a volunteer leaderboard to ensure there were no breaking changes.
