### PR TITLE
Bug report footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import NotFound from './containers/notFound';
 import NavBar from './components/navBar';
 import Reservations from './containers/reservations';
 import AuthRedirect from './components/authRedirect';
+import SiteFooter from './components/siteFooter';
 
 const { Content } = Layout;
 
@@ -190,6 +191,7 @@ const App: React.FC = () => {
               }
             })()}
           </Content>
+          <SiteFooter />
         </AppLayout>
       </Router>
     </>

--- a/src/components/siteFooter/index.tsx
+++ b/src/components/siteFooter/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Layout, Typography } from 'antd';
+import { BugOutlined } from '@ant-design/icons';
+
+const { Footer } = Layout;
+const { Text, Link } = Typography;
+
+const SiteFooter: React.FC = () => {
+  return (
+    <>
+      <Footer>
+        <BugOutlined />
+        <Text> Notice something off? </Text>
+        <Link href="https://forms.gle/4dLLYX4z5MMsgaAq7" target="_blank">
+          Submit a Bug Report!
+        </Link>
+      </Footer>
+    </>
+  );
+};
+
+export default SiteFooter;

--- a/src/components/siteFooter/index.tsx
+++ b/src/components/siteFooter/index.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import { Layout, Typography } from 'antd';
 import { BugOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
 
 const { Footer } = Layout;
 const { Text, Link } = Typography;
 
+const StyledFooter = styled(Footer)`
+  padding-top: 12px;
+  padding-bottom: 12px;
+  margin: auto;
+`;
+
 const SiteFooter: React.FC = () => {
   return (
     <>
-      <Footer>
+      <StyledFooter>
         <BugOutlined />
         <Text> Notice something off? </Text>
         <Link href="https://forms.gle/4dLLYX4z5MMsgaAq7" target="_blank">
           Submit a Bug Report!
         </Link>
-      </Footer>
+      </StyledFooter>
     </>
   );
 };


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1152597582)

Added a footer to the bottom of the site with a link to a bug reporting form.

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

Added a custom footer in the App. Used the default AntD Footer component but styled to reduce the vertical padding and to center the content.

The footer is at the bottom of all content, in most pages you have to scroll to see it, including the map page (see the attached screenshots and notice the page is scrolled).

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots


<img width="1440" alt="Screen Shot 2021-03-30 at 5 17 14 PM" src="https://user-images.githubusercontent.com/30527441/113058764-906d8180-917c-11eb-9598-9ce927b9dcf7.png">
<img width="1440" alt="Screen Shot 2021-03-30 at 5 17 29 PM" src="https://user-images.githubusercontent.com/30527441/113058766-91061800-917c-11eb-8a35-0b0c5939ed9c.png">
<img width="1440" alt="Screen Shot 2021-03-30 at 5 17 31 PM" src="https://user-images.githubusercontent.com/30527441/113059134-15589b00-917d-11eb-8cbf-89e72baf4581.png">


<!-- Provide screenshots of any new components, styling changes, or pages. --> 

## Verification Steps

Checked that the link works and the footer looks reasonable on chrome, firefox, and safari

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
