### PR TITLE
Create Tree Popup

### DIFF
--- a/src/components/treePopup/index.tsx
+++ b/src/components/treePopup/index.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Typography } from 'antd';
+import { LinkButton } from '../linkButton';
+import { Routes } from '../../App';
+import {
+  BLACK,
+  DARK_GREY,
+  LIGHT_GREEN,
+  LIGHT_GREY,
+  MID_GREEN,
+  WHITE,
+} from '../../utils/colors';
+
+const { Paragraph } = Typography;
+
+const PopupContainer = styled.div`
+  position: absolute;
+`;
+
+const PopupAnchor = styled.div`
+  /* position tip */
+  position: absolute;
+  width: 100%;
+  bottom: 8px;
+  left: 0;
+
+  /* draw tip */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translate(-50%, 0);
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-top: 8px solid ${WHITE};
+  }
+`;
+
+const PopupBubble = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -100%);
+  background-color: ${WHITE};
+  width: 250px;
+  height: 150px;
+  padding: 7px 15px;
+  border-radius: 2px;
+  box-shadow: 0px 2px 10px 1px ${BLACK}50;
+`;
+
+const TreeTitle = styled(Paragraph)`
+  font-size: 20px;
+  line-height: 28px;
+  color: ${MID_GREEN};
+`;
+
+const Line = styled.div`
+  width: 250px;
+  height: 2px;
+  margin: -15px 0 10px -15px;
+  background: ${LIGHT_GREY};
+`;
+
+const GreyText = styled(Paragraph)`
+  color: ${DARK_GREY};
+  font-size: 13px;
+  line-height: 13px;
+`;
+
+const GreenLinkButton = styled(LinkButton)`
+  background-color: ${LIGHT_GREEN};
+  border-color: ${LIGHT_GREEN};
+  color: ${WHITE};
+`;
+
+export interface BasicTreeInfo {
+  id: number;
+  commonName: string;
+  address: string;
+}
+
+interface TreePopupProps {
+  popRef: React.RefObject<HTMLDivElement>;
+  treeInfo: BasicTreeInfo;
+}
+
+export const TreePopup: React.FC<TreePopupProps> = ({ popRef, treeInfo }) => {
+  return (
+    <PopupContainer ref={popRef}>
+      <PopupAnchor>
+        <PopupBubble>
+          <TreeTitle>{treeInfo.commonName}</TreeTitle>
+          <Line />
+          <GreyText strong>Nearby Address</GreyText>
+          <GreyText>{treeInfo.address}</GreyText>
+          {/* TODO change to tree page route */}
+          <GreenLinkButton to={`${Routes.NOT_FOUND}/${treeInfo.id}`}>
+            More Info
+          </GreenLinkButton>
+        </PopupBubble>
+      </PopupAnchor>
+    </PopupContainer>
+  );
+};
+
+export default TreePopup;


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/926131646)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Creates popup to let viewers see more information about a tree/navigate to that tree's page on the map.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Created the popup component to be linked to the map as a [custom popup](https://developers.google.com/maps/documentation/javascript/examples/overlay-popup#all) (rather than an info window to allow for increased customization)
- tried using AntD's popover but this doesn't work well with the map for placement and toggling visibility
- `popRef` is for integration with the map

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
<img width="1344" alt="Tree Popover" src="https://user-images.githubusercontent.com/22990100/115609575-b38bdc80-a2b5-11eb-87b6-3f8b3fa52a91.png">
<img width="1344" alt="Tree Popover Zoom" src="https://user-images.githubusercontent.com/22990100/115609578-b4bd0980-a2b5-11eb-8c9c-e878fb317f9c.png">


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually confirmed it matched the designs, placed it onto the map blocks layer to make sure it would work well once the sites are added
