### PR TITLE
Keep Login/Signup Form Values on Resize

### DIFF
--- a/src/components/loginForm/index.tsx
+++ b/src/components/loginForm/index.tsx
@@ -4,7 +4,8 @@ import { Button, Form, Input } from 'antd';
 import styled from 'styled-components';
 import { WindowTypes } from '../windowDimensions';
 import { FormHalfItem, FormRow, Gap } from '../themedComponents';
-import { FormInstance, Rule } from 'antd/es/form';
+import { FormInstance } from 'antd/es/form';
+import { enterEmailRules, loginPasswordRules } from '../../utils/formRules';
 
 interface LoginFormProps {
   readonly formInstance: FormInstance;
@@ -21,18 +22,6 @@ const StyledFormItem = styled(Form.Item)`
   margin-bottom: 10px;
 `;
 
-const emailRules: Rule[] = [
-  { required: true, message: 'Please input your email!' },
-  { type: 'email', message: 'Not a valid email address' },
-];
-
-const passwordRules: Rule[] = [
-  {
-    required: true,
-    message: 'Please input your password!',
-  },
-];
-
 const LoginForm: React.FC<LoginFormProps> = ({
   formInstance,
   onFinish,
@@ -47,10 +36,10 @@ const LoginForm: React.FC<LoginFormProps> = ({
             case WindowTypes.Tablet:
               return (
                 <>
-                  <Form.Item name="email" rules={emailRules}>
+                  <Form.Item name="email" rules={enterEmailRules}>
                     <Input placeholder="Email" />
                   </Form.Item>
-                  <Form.Item name="password" rules={passwordRules}>
+                  <Form.Item name="password" rules={loginPasswordRules}>
                     <Input.Password placeholder="Password" />
                   </Form.Item>
 
@@ -66,11 +55,11 @@ const LoginForm: React.FC<LoginFormProps> = ({
               return (
                 <>
                   <FormRow>
-                    <FormHalfItem name="email" rules={emailRules}>
+                    <FormHalfItem name="email" rules={enterEmailRules}>
                       <Input placeholder="Email" />
                     </FormHalfItem>
                     <Gap />
-                    <FormHalfItem name="password" rules={passwordRules}>
+                    <FormHalfItem name="password" rules={loginPasswordRules}>
                       <Input.Password placeholder="Password" />
                     </FormHalfItem>
                   </FormRow>

--- a/src/components/loginForm/index.tsx
+++ b/src/components/loginForm/index.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { LoginRequest } from '../../auth/ducks/types';
 import { Button, Form, Input } from 'antd';
 import styled from 'styled-components';
-import useWindowDimensions, { WindowTypes } from '../windowDimensions';
+import { WindowTypes } from '../windowDimensions';
 import { FormHalfItem, FormRow, Gap } from '../themedComponents';
+import { FormInstance, Rule } from 'antd/es/form';
 
 interface LoginFormProps {
+  readonly formInstance: FormInstance;
   readonly onFinish: (values: LoginRequest) => void;
+  readonly windowType: WindowTypes;
 }
 
 const LoginButton = styled(Button)`
@@ -18,45 +21,36 @@ const StyledFormItem = styled(Form.Item)`
   margin-bottom: 10px;
 `;
 
-const LoginForm: React.FC<LoginFormProps> = ({ onFinish }) => {
-  const { windowType } = useWindowDimensions();
+const emailRules: Rule[] = [
+  { required: true, message: 'Please input your email!' },
+  { type: 'email', message: 'Not a valid email address' },
+];
 
+const passwordRules: Rule[] = [
+  {
+    required: true,
+    message: 'Please input your password!',
+  },
+];
+
+const LoginForm: React.FC<LoginFormProps> = ({
+  formInstance,
+  onFinish,
+  windowType,
+}) => {
   return (
     <>
-      <Form
-        name="basic"
-        initialValues={{
-          remember: true,
-        }}
-        onFinish={onFinish}
-      >
+      <Form name="basic" form={formInstance} onFinish={onFinish}>
         {(() => {
           switch (windowType) {
             case WindowTypes.Mobile:
             case WindowTypes.Tablet:
               return (
                 <>
-                  <Form.Item
-                    name="email"
-                    rules={[
-                      { required: true, message: 'Please input your email!' },
-                      {
-                        pattern: /^\S+@\S+\.\S{2,}$/,
-                        message: 'Not a valid email address',
-                      },
-                    ]}
-                  >
+                  <Form.Item name="email" rules={emailRules}>
                     <Input placeholder="Email" />
                   </Form.Item>
-                  <Form.Item
-                    name="password"
-                    rules={[
-                      {
-                        required: true,
-                        message: 'Please input your password!',
-                      },
-                    ]}
-                  >
+                  <Form.Item name="password" rules={passwordRules}>
                     <Input.Password placeholder="Password" />
                   </Form.Item>
 
@@ -72,31 +66,11 @@ const LoginForm: React.FC<LoginFormProps> = ({ onFinish }) => {
               return (
                 <>
                   <FormRow>
-                    <FormHalfItem
-                      name="email"
-                      rules={[
-                        {
-                          required: true,
-                          message: 'Please input your email!',
-                        },
-                        {
-                          pattern: /^\S+@\S+\.\S{2,}$/,
-                          message: 'Not a valid email address',
-                        },
-                      ]}
-                    >
+                    <FormHalfItem name="email" rules={emailRules}>
                       <Input placeholder="Email" />
                     </FormHalfItem>
                     <Gap />
-                    <FormHalfItem
-                      name="password"
-                      rules={[
-                        {
-                          required: true,
-                          message: 'Please input your password!',
-                        },
-                      ]}
-                    >
+                    <FormHalfItem name="password" rules={passwordRules}>
                       <Input.Password placeholder="Password" />
                     </FormHalfItem>
                   </FormRow>

--- a/src/components/signupForm/index.tsx
+++ b/src/components/signupForm/index.tsx
@@ -12,7 +12,8 @@ import {
   FullWidthSpace,
   Gap,
 } from '../themedComponents';
-import useWindowDimensions, { WindowTypes } from '../windowDimensions';
+import { WindowTypes } from '../windowDimensions';
+import { FormInstance } from 'antd/es/form';
 
 const { Paragraph } = Typography;
 
@@ -24,18 +25,23 @@ const Footer: typeof Paragraph = styled(Paragraph)<ParagraphProps>`
 `;
 
 interface SignupFormProps {
+  readonly formInstance: FormInstance;
   readonly onFinish: (values: SignupRequest) => void;
+  readonly windowType: WindowTypes;
 }
 
-const SignupForm: React.FC<SignupFormProps> = ({ onFinish }) => {
-  const { windowType } = useWindowDimensions();
-
+const SignupForm: React.FC<SignupFormProps> = ({
+  formInstance,
+  onFinish,
+  windowType,
+}) => {
   return (
     <>
-      <Form name="basic" initialValues={{ remember: true }} onFinish={onFinish}>
+      <Form name="basic" form={formInstance} onFinish={onFinish}>
         <FullWidthSpace direction="vertical" size={1}>
           <FormRow>
             <FormHalfItem
+              name="firstName"
               rules={[
                 {
                   required: true,
@@ -68,10 +74,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ onFinish }) => {
             name="email"
             rules={[
               { required: true, message: 'Please input your email!' },
-              {
-                pattern: /^\S+@\S+\.\S{2,}$/,
-                message: 'Not a valid email address',
-              },
+              { type: 'email', message: 'Not a valid email address' },
             ]}
           >
             <Input placeholder="Email" />

--- a/src/components/signupForm/index.tsx
+++ b/src/components/signupForm/index.tsx
@@ -14,6 +14,14 @@ import {
 } from '../themedComponents';
 import { WindowTypes } from '../windowDimensions';
 import { FormInstance } from 'antd/es/form';
+import {
+  confirmPasswordRules,
+  enterEmailRules,
+  firstNameRules,
+  lastNameRules,
+  newPasswordRules,
+  usernameRules,
+} from '../../utils/formRules';
 
 const { Paragraph } = Typography;
 
@@ -40,75 +48,27 @@ const SignupForm: React.FC<SignupFormProps> = ({
       <Form name="basic" form={formInstance} onFinish={onFinish}>
         <FullWidthSpace direction="vertical" size={1}>
           <FormRow>
-            <FormHalfItem
-              name="firstName"
-              rules={[
-                {
-                  required: true,
-                  message: 'Please input your first name!',
-                },
-              ]}
-            >
+            <FormHalfItem name="firstName" rules={firstNameRules}>
               <Input placeholder="First Name" />
             </FormHalfItem>
             <Gap />
-            <FormHalfItem
-              name="lastName"
-              rules={[
-                {
-                  required: true,
-                  message: 'Please input your last name!',
-                },
-              ]}
-            >
+            <FormHalfItem name="lastName" rules={lastNameRules}>
               <Input placeholder="Last Name" />
             </FormHalfItem>
           </FormRow>
-          <Form.Item
-            name="username"
-            rules={[{ required: true, message: 'Please enter a username!' }]}
-          >
+          <Form.Item name="username" rules={usernameRules}>
             <Input placeholder="Username" />
           </Form.Item>
-          <Form.Item
-            name="email"
-            rules={[
-              { required: true, message: 'Please input your email!' },
-              { type: 'email', message: 'Not a valid email address' },
-            ]}
-          >
+          <Form.Item name="email" rules={enterEmailRules}>
             <Input placeholder="Email" />
           </Form.Item>
-          <Form.Item
-            name="password"
-            rules={[
-              { required: true, message: 'Please enter a password!' },
-              {
-                min: 8,
-                message: 'Password must be at least 8 characters long',
-              },
-            ]}
-          >
+          <Form.Item name="password" rules={newPasswordRules}>
             <Input.Password placeholder="Password" />
           </Form.Item>
           <Form.Item
             name="confirmPassword"
             dependencies={['password']}
-            rules={[
-              {
-                required: true,
-                message: 'Please confirm your password!',
-              },
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  const password = getFieldValue('password');
-                  if (value && password !== value) {
-                    return Promise.reject('Passwords do not match');
-                  }
-                  return Promise.resolve();
-                },
-              }),
-            ]}
+            rules={confirmPasswordRules(formInstance)}
           >
             <Input.Password placeholder="Confirm Password" />
           </Form.Item>

--- a/src/containers/login/index.tsx
+++ b/src/containers/login/index.tsx
@@ -13,7 +13,7 @@ import {
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { asyncRequestIsFailed } from '../../utils/asyncRequest';
 import { RedirectStateProps, Routes } from '../../App';
-import { Alert, Col, Row, Typography } from 'antd';
+import { Alert, Col, Form, Row, Typography } from 'antd';
 import styled from 'styled-components';
 import { BLACK, LIGHT_GREY, TEXT_GREY, WHITE } from '../../utils/colors';
 import {
@@ -101,6 +101,7 @@ const Login: React.FC<LoginProps> = ({ tokens }) => {
   const privilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(state.authenticationState.tokens),
   );
+  const [loginForm] = Form.useForm();
 
   const destination: Routes = location.state
     ? location.state.destination
@@ -155,7 +156,11 @@ const Login: React.FC<LoginProps> = ({ tokens }) => {
                 {loginFailed && (
                   <MobileLoginAlert message={LOGIN_ERROR} type="error" />
                 )}
-                <LoginForm onFinish={onFinish} />
+                <LoginForm
+                  formInstance={loginForm}
+                  onFinish={onFinish}
+                  windowType={windowType}
+                />
                 {ForgotPasswordFooter}
               </MobileLoginPageContainer>
             );
@@ -170,7 +175,11 @@ const Login: React.FC<LoginProps> = ({ tokens }) => {
                       {loginFailed && (
                         <LoginAlert message={LOGIN_ERROR} type="error" />
                       )}
-                      <LoginForm onFinish={onFinish} />
+                      <LoginForm
+                        formInstance={loginForm}
+                        onFinish={onFinish}
+                        windowType={windowType}
+                      />
                       {ForgotPasswordFooter}
                     </TabletInputContainer>
                   </CenterDiv>
@@ -199,7 +208,11 @@ const Login: React.FC<LoginProps> = ({ tokens }) => {
                       {loginFailed && (
                         <LoginAlert message={LOGIN_ERROR} type="error" />
                       )}
-                      <LoginForm onFinish={onFinish} />
+                      <LoginForm
+                        formInstance={loginForm}
+                        onFinish={onFinish}
+                        windowType={windowType}
+                      />
                       {ForgotPasswordFooter}
                     </InputContainer>
 

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useLocation } from 'react-router';
 import { useHistory } from 'react-router-dom';
-import { Alert, Col, Row, Typography } from 'antd';
+import { Alert, Col, Form, Row, Typography } from 'antd';
 import { Helmet } from 'react-helmet';
 import GreetingContainer from '../../components/greetingContainer';
 import { signup } from '../../auth/ducks/thunks';
@@ -88,6 +88,7 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
   const privilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(state.authenticationState.tokens),
   );
+  const [signupForm] = Form.useForm();
 
   if (privilegeLevel !== PrivilegeLevel.NONE) {
     const destination = location.state
@@ -124,7 +125,11 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
                   {tokens.kind === AsyncRequestKinds.Failed && (
                     <MobileSignupAlert message={tokens.error} type="error" />
                   )}
-                  <SignupForm onFinish={onFinish} />
+                  <SignupForm
+                    formInstance={signupForm}
+                    onFinish={onFinish}
+                    windowType={windowType}
+                  />
                 </MobileSignupPageContainer>
               </>
             );
@@ -139,7 +144,11 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
                     <TabletInputContainer>
                       <Title>{SIGNUP_TITLE}</Title>
                       <TabletLine />
-                      <SignupForm onFinish={onFinish} />
+                      <SignupForm
+                        formInstance={signupForm}
+                        onFinish={onFinish}
+                        windowType={windowType}
+                      />
                     </TabletInputContainer>
                   </CenterDiv>
 
@@ -169,7 +178,11 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
                       <InputContainer span={11}>
                         <Title>{SIGNUP_TITLE}</Title>
                         <Line />
-                        <SignupForm onFinish={onFinish} />
+                        <SignupForm
+                          formInstance={signupForm}
+                          onFinish={onFinish}
+                          windowType={windowType}
+                        />
                       </InputContainer>
 
                       <Col span={2} />

--- a/src/utils/formRules.tsx
+++ b/src/utils/formRules.tsx
@@ -1,4 +1,4 @@
-import { FormInstance, Rule, RuleObject } from 'antd/es/form';
+import { FormInstance, Rule } from 'antd/es/form';
 
 export const enterEmailRules: Rule[] = [
   { required: true, message: 'Please input your email!' },

--- a/src/utils/formRules.tsx
+++ b/src/utils/formRules.tsx
@@ -1,0 +1,57 @@
+import { FormInstance, Rule, RuleObject } from 'antd/es/form';
+
+export const enterEmailRules: Rule[] = [
+  { required: true, message: 'Please input your email!' },
+  { type: 'email', message: 'Not a valid email address' },
+];
+
+export const loginPasswordRules: Rule[] = [
+  {
+    required: true,
+    message: 'Please input your password!',
+  },
+];
+
+export const newPasswordRules: Rule[] = [
+  { required: true, message: 'Please enter a password!' },
+  {
+    min: 8,
+    message: 'Password must be at least 8 characters long',
+  },
+];
+
+export const confirmPasswordRules = (form: FormInstance): Rule[] => {
+  return [
+    {
+      required: true,
+      message: 'Please confirm your password!',
+    },
+    {
+      validator(_, value) {
+        const password = form.getFieldValue('password');
+        if (value && password !== value) {
+          return Promise.reject('Passwords do not match');
+        }
+        return Promise.resolve();
+      },
+    },
+  ];
+};
+
+export const firstNameRules: Rule[] = [
+  {
+    required: true,
+    message: 'Please input your first name!',
+  },
+];
+
+export const lastNameRules: Rule[] = [
+  {
+    required: true,
+    message: 'Please input your last name!',
+  },
+];
+
+export const usernameRules: Rule[] = [
+  { required: true, message: 'Please enter a username!' },
+];


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/1012460652)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Prevents form fields from being cleared on window resize.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Used `Form.useForm` to keep form instance consistent across forms rendered on different window types
- Passed `windowType` to forms as a prop rather than having both pages and forms use the `useWindowDimensions` hook (less event listeners)

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
No styling changes.

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Ran locally, input values into form fields and resized the browser past each breakpoint to check that
- layout updated according to designs
- values did not clear past breakpoints