### PR TITLE
Connect Sites Geojson Route

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -4,6 +4,7 @@ import { TeamLeaderboardItem } from '../containers/teamLeaderboard/ducks/types';
 import {
   BlockGeoData,
   NeighborhoodGeoData,
+  SiteGeoData,
 } from '../components/mapPageComponents/ducks/types';
 
 export interface ApiExtraArgs {
@@ -19,6 +20,7 @@ export interface ApiClient {
   ) => Promise<TeamLeaderboardItem[]>;
   readonly getBlockGeoData: () => Promise<BlockGeoData>;
   readonly getNeighborhoodGeoData: () => Promise<NeighborhoodGeoData>;
+  readonly getSiteGeoData: () => Promise<SiteGeoData>;
 }
 
 export enum ApiClientRoutes {
@@ -26,6 +28,7 @@ export enum ApiClientRoutes {
   TEAMS_LEADERBOARD = '/api/v1/leaderboard/teams',
   GET_ALL_BLOCKS = '/api/v1/map/blocks',
   GET_ALL_NEIGHBORHOODS = '/api/v1/map/neighborhoods',
+  GET_ALL_SITES = '/api/v1/map/sites',
 }
 
 const getUsersLeaderboard = (
@@ -56,11 +59,18 @@ const getNeighborhoodGeoData = (): Promise<NeighborhoodGeoData> => {
     .catch((e) => e);
 };
 
+const getSiteGeoData = (): Promise<SiteGeoData> => {
+  return AppAxiosInstance.get(ApiClientRoutes.GET_ALL_SITES)
+    .then((res) => res.data)
+    .catch((err) => err);
+};
+
 const Client: ApiClient = Object.freeze({
   getUsersLeaderboard,
   getTeamsLeaderboard,
   getBlockGeoData,
   getNeighborhoodGeoData,
+  getSiteGeoData,
 });
 
 export default Client;

--- a/src/api/test/apiClient.test.ts
+++ b/src/api/test/apiClient.test.ts
@@ -1,6 +1,7 @@
 import {
   BlockGeoData,
   NeighborhoodGeoData,
+  SiteGeoData,
 } from '../../components/mapPageComponents/ducks/types';
 import ApiClient, { ApiClientRoutes } from '../apiClient';
 import nock from 'nock';
@@ -81,6 +82,41 @@ describe('Authentication Client Tests', () => {
       const result = await ApiClient.getBlockGeoData();
 
       expect(result).toEqual(response);
+    });
+
+    describe('Sites', () => {
+      it('makes the right request', async () => {
+        const response: SiteGeoData = {
+          type: 'FeatureCollection',
+          name: 'sites',
+          features: [
+            {
+              type: 'Feature',
+              properties: {
+                id: 213,
+                treePresent: true,
+                diameter: 29.8,
+                species: 'Willow',
+                updatedAt: 'December 17, 1995 03:24:00',
+                updatedBy: 'username',
+                address: '123 Street',
+                lat: 42.3488784985,
+                lng: -71.0293810011,
+              },
+              geometry: {
+                type: 'Point',
+                coordinates: [-71.0293810011, 42.3488784985],
+              },
+            },
+          ],
+        };
+
+        nock(BASE_URL).get(ApiClientRoutes.GET_ALL_SITES).reply(200, response);
+
+        const result = await ApiClient.getSiteGeoData();
+
+        expect(result).toEqual(response);
+      });
     });
   });
 });

--- a/src/components/mapPageComponents/ducks/actions.ts
+++ b/src/components/mapPageComponents/ducks/actions.ts
@@ -1,5 +1,5 @@
 import { genericAsyncActions } from '../../../utils/asyncRequest';
-import { BlockGeoData, NeighborhoodGeoData } from './types';
+import { BlockGeoData, NeighborhoodGeoData, SiteGeoData } from './types';
 
 export const blockGeoData = genericAsyncActions<BlockGeoData, any>();
 
@@ -8,10 +8,15 @@ export const neighborhoodGeoData = genericAsyncActions<
   any
 >();
 
+export const siteGeoData = genericAsyncActions<SiteGeoData, any>();
+
 export type MapActions =
   | ReturnType<typeof blockGeoData.loading>
   | ReturnType<typeof blockGeoData.loaded>
   | ReturnType<typeof blockGeoData.failed>
   | ReturnType<typeof neighborhoodGeoData.loading>
   | ReturnType<typeof neighborhoodGeoData.loaded>
-  | ReturnType<typeof neighborhoodGeoData.failed>;
+  | ReturnType<typeof neighborhoodGeoData.failed>
+  | ReturnType<typeof siteGeoData.loading>
+  | ReturnType<typeof siteGeoData.loaded>
+  | ReturnType<typeof siteGeoData.failed>;

--- a/src/components/mapPageComponents/ducks/reducer.ts
+++ b/src/components/mapPageComponents/ducks/reducer.ts
@@ -2,6 +2,7 @@ import {
   BlockGeoData,
   NeighborhoodGeoData,
   MapGeoDataReducerState,
+  SiteGeoData,
 } from './types';
 import {
   ASYNC_REQUEST_FAILED_ACTION,
@@ -10,12 +11,13 @@ import {
   AsyncRequestNotStarted,
   generateAsyncRequestReducer,
 } from '../../../utils/asyncRequest';
-import { blockGeoData, neighborhoodGeoData } from './actions';
+import { blockGeoData, neighborhoodGeoData, siteGeoData } from './actions';
 import { C4CAction } from '../../../store';
 
 export const initialMapGeoDataState: MapGeoDataReducerState = {
   blockGeoData: AsyncRequestNotStarted<BlockGeoData, any>(),
   neighborhoodGeoData: AsyncRequestNotStarted<NeighborhoodGeoData, any>(),
+  siteGeoData: AsyncRequestNotStarted<SiteGeoData, any>(),
 };
 
 const blockGeoDataReducer = generateAsyncRequestReducer<
@@ -29,6 +31,12 @@ const neighborhoodGeoDataReducer = generateAsyncRequestReducer<
   NeighborhoodGeoData,
   void
 >(neighborhoodGeoData.key);
+
+const siteGeoDataReducer = generateAsyncRequestReducer<
+  MapGeoDataReducerState,
+  SiteGeoData,
+  void
+>(siteGeoData.key);
 
 const reducers = (
   state: MapGeoDataReducerState = initialMapGeoDataState,
@@ -45,6 +53,7 @@ const reducers = (
           state.neighborhoodGeoData,
           action,
         ),
+        siteGeoData: siteGeoDataReducer(state.siteGeoData, action),
       };
     default:
       return state;

--- a/src/components/mapPageComponents/ducks/test/reducers.test.ts
+++ b/src/components/mapPageComponents/ducks/test/reducers.test.ts
@@ -1,0 +1,128 @@
+import { blockGeoData, neighborhoodGeoData, siteGeoData } from '../actions';
+import reducers, { initialMapGeoDataState } from '../reducer';
+import {
+  BlockGeoData,
+  NeighborhoodGeoData,
+  SiteGeoData,
+  MapGeoDataReducerState,
+} from '../types';
+import { AsyncRequestCompleted } from '../../../../utils/asyncRequest';
+
+describe('Map Reducers', () => {
+  describe('BlockGeoData', () => {
+    it('Updates state correctly when block data is retrieved', () => {
+      const blockData: BlockGeoData = {
+        type: 'FeatureCollection',
+        name: 'blocks',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              blockId: 1714,
+              lat: 42.3488784985,
+              lng: -71.0293810011,
+            },
+            geometry: {
+              type: 'MultiPolygon',
+              coordinates: [
+                [
+                  [
+                    [-71.02859399925286, 42.34889700150278],
+                    [-71.02912299801895, 42.34837799993562],
+                  ],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+      const action = blockGeoData.loaded(blockData);
+      const expectedNextState: MapGeoDataReducerState = {
+        ...initialMapGeoDataState,
+        blockGeoData: AsyncRequestCompleted<BlockGeoData, void>(blockData),
+      };
+      expect(reducers(initialMapGeoDataState, action)).toEqual(
+        expectedNextState,
+      );
+    });
+  });
+
+  describe('NeighborhoodGeoData', () => {
+    it('Updates state correctly when neighborhood data is retrieved', () => {
+      const neighborhoodData: NeighborhoodGeoData = {
+        type: 'FeatureCollection',
+        name: 'neighborhoods',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              neighborhoodId: 15,
+              name: 'Roslindale',
+              completionPerc: 0,
+              lat: 42.2803,
+              lng: -71.1266,
+            },
+            geometry: {
+              type: 'MultiPolygon',
+              coordinates: [
+                [
+                  [
+                    [-71.12592717485386, 42.272013107957406],
+                    [-71.12610933458738, 42.2716219294518],
+                  ],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+      const action = neighborhoodGeoData.loaded(neighborhoodData);
+      const expectedNextState: MapGeoDataReducerState = {
+        ...initialMapGeoDataState,
+        neighborhoodGeoData: AsyncRequestCompleted<NeighborhoodGeoData, void>(
+          neighborhoodData,
+        ),
+      };
+      expect(reducers(initialMapGeoDataState, action)).toEqual(
+        expectedNextState,
+      );
+    });
+  });
+
+  describe('SiteGeoData', () => {
+    it('Updates state correctly when site data is retrieved', () => {
+      const siteData: SiteGeoData = {
+        type: 'FeatureCollection',
+        name: 'sites',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              id: 213,
+              treePresent: true,
+              diameter: 29.8,
+              species: 'Willow',
+              updatedAt: 'December 17, 1995 03:24:00',
+              updatedBy: 'username',
+              address: '123 Street',
+              lat: 42.3488784985,
+              lng: -71.0293810011,
+            },
+            geometry: {
+              type: 'Point',
+              coordinates: [[[[-71.02859399925286, 42.34889700150278]]]],
+            },
+          },
+        ],
+      };
+      const action = siteGeoData.loaded(siteData);
+      const expectedNextState: MapGeoDataReducerState = {
+        ...initialMapGeoDataState,
+        siteGeoData: AsyncRequestCompleted<SiteGeoData, void>(siteData),
+      };
+      expect(reducers(initialMapGeoDataState, action)).toEqual(
+        expectedNextState,
+      );
+    });
+  });
+});

--- a/src/components/mapPageComponents/ducks/test/thunks.test.ts
+++ b/src/components/mapPageComponents/ducks/test/thunks.test.ts
@@ -1,0 +1,180 @@
+import { BlockGeoData, NeighborhoodGeoData, SiteGeoData } from '../types';
+import { getMapGeoData } from '../thunks';
+import { blockGeoData, neighborhoodGeoData, siteGeoData } from '../actions';
+import { C4CState, initialStoreState, ThunkExtraArgs } from '../../../../store';
+import authClient from '../../../../auth/authClient';
+import apiClient from '../../../../api/apiClient';
+import protectedApiClient from '../../../../api/protectedApiClient';
+
+export const generateState = (partialState: Partial<C4CState>): C4CState => ({
+  ...initialStoreState,
+  ...partialState,
+});
+
+describe('Map Thunks', () => {
+  describe('getMapGeoData', () => {
+    it('dispatches blockGeoData.loaded(), neighborhoodGeoData.loaded(), and siteGeoData.loaded actions after getting map data', async () => {
+      const getState = () => generateState({});
+      const mockDispatch = jest.fn();
+      const mockGetBlockGeoData = jest.fn();
+      const mockGetNeighborhoodGeoData = jest.fn();
+      const mockGetSiteGeoData = jest.fn();
+      const mockBlockDataResponse: BlockGeoData = {
+        type: 'FeatureCollection',
+        name: 'blocks',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              blockId: 1714,
+              lat: 42.3488784985,
+              lng: -71.0293810011,
+            },
+            geometry: {
+              type: 'MultiPolygon',
+              coordinates: [
+                [
+                  [
+                    [-71.02859399925286, 42.34889700150278],
+                    [-71.02912299801895, 42.34837799993562],
+                  ],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+      const mockNeighborhoodDataResponse: NeighborhoodGeoData = {
+        type: 'FeatureCollection',
+        name: 'neighborhoods',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              neighborhoodId: 15,
+              name: 'Roslindale',
+              completionPerc: 0,
+              lat: 42.2803,
+              lng: -71.1266,
+            },
+            geometry: {
+              type: 'MultiPolygon',
+              coordinates: [
+                [
+                  [
+                    [-71.12592717485386, 42.272013107957406],
+                    [-71.12610933458738, 42.2716219294518],
+                  ],
+                ],
+              ],
+            },
+          },
+        ],
+      };
+      const mockSiteDataResponse: SiteGeoData = {
+        type: 'FeatureCollection',
+        name: 'sites',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              id: 213,
+              treePresent: true,
+              diameter: 29.8,
+              species: 'Willow',
+              updatedAt: 'December 17, 1995 03:24:00',
+              updatedBy: 'username',
+              address: '123 Street',
+              lat: 42.3488784985,
+              lng: -71.0293810011,
+            },
+            geometry: {
+              type: 'Point',
+              coordinates: [[[[-71.02859399925286, 42.34889700150278]]]],
+            },
+          },
+        ],
+      };
+
+      mockGetBlockGeoData.mockResolvedValue(mockBlockDataResponse);
+      mockGetNeighborhoodGeoData.mockResolvedValue(
+        mockNeighborhoodDataResponse,
+      );
+      mockGetSiteGeoData.mockResolvedValue(mockSiteDataResponse);
+      const mockExtraArgs: ThunkExtraArgs = {
+        authClient,
+        protectedApiClient,
+        apiClient: {
+          ...apiClient,
+          getBlockGeoData: mockGetBlockGeoData,
+          getNeighborhoodGeoData: mockGetNeighborhoodGeoData,
+          getSiteGeoData: mockGetSiteGeoData,
+        },
+      };
+
+      await getMapGeoData()(mockDispatch, getState, mockExtraArgs);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(6);
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        4,
+        blockGeoData.loaded(mockBlockDataResponse),
+      );
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        5,
+        neighborhoodGeoData.loaded(mockNeighborhoodDataResponse),
+      );
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        6,
+        siteGeoData.loaded(mockSiteDataResponse),
+      );
+      expect(mockGetBlockGeoData).toBeCalledTimes(1);
+      expect(mockGetNeighborhoodGeoData).toBeCalledTimes(1);
+      expect(mockGetSiteGeoData).toBeCalledTimes(1);
+    });
+
+    it('dispatches blockGeoData.failed(), neighborhoodGeoData.failed(), and siteGeoData.failed() actions when API fails', async () => {
+      const getState = () => generateState({});
+      const mockDispatch = jest.fn();
+      const mockGetBlockGeoData = jest.fn();
+      const mockGetNeighborhoodGeoData = jest.fn();
+      const mockGetSiteGeoData = jest.fn();
+      const mockAPIError = {
+        response: {
+          data: 'Failed',
+        },
+      };
+      mockGetBlockGeoData.mockRejectedValue(mockAPIError);
+      mockGetNeighborhoodGeoData.mockRejectedValue(mockAPIError);
+      mockGetSiteGeoData.mockRejectedValue(mockAPIError);
+      const mockExtraArgs: ThunkExtraArgs = {
+        authClient,
+        protectedApiClient,
+        apiClient: {
+          ...apiClient,
+          getBlockGeoData: mockGetBlockGeoData,
+          getNeighborhoodGeoData: mockGetNeighborhoodGeoData,
+          getSiteGeoData: mockGetSiteGeoData,
+        },
+      };
+
+      await getMapGeoData()(mockDispatch, getState, mockExtraArgs);
+
+      expect(mockDispatch).toHaveBeenCalledTimes(6);
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        4,
+        blockGeoData.failed(mockAPIError),
+      );
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        5,
+        neighborhoodGeoData.failed(mockAPIError),
+      );
+      expect(mockDispatch).toHaveBeenNthCalledWith(
+        6,
+        siteGeoData.failed(mockAPIError),
+      );
+      expect(mockGetBlockGeoData).toBeCalledTimes(1);
+      expect(mockGetNeighborhoodGeoData).toBeCalledTimes(1);
+      expect(mockGetSiteGeoData).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/components/mapPageComponents/ducks/thunks.ts
+++ b/src/components/mapPageComponents/ducks/thunks.ts
@@ -2,24 +2,29 @@ import {
   BlockGeoData,
   NeighborhoodGeoData,
   MapGeoDataThunkAction,
+  SiteGeoData,
 } from './types';
-import { blockGeoData, neighborhoodGeoData } from './actions';
+import { blockGeoData, neighborhoodGeoData, siteGeoData } from './actions';
 
 export const getMapGeoData = (): MapGeoDataThunkAction<void> => {
   return (dispatch, getState, { apiClient }) => {
     dispatch(blockGeoData.loading());
     dispatch(neighborhoodGeoData.loading());
+    dispatch(siteGeoData.loading());
     return Promise.all([
       apiClient.getBlockGeoData(),
       apiClient.getNeighborhoodGeoData(),
+      apiClient.getSiteGeoData(),
     ])
-      .then((response: [BlockGeoData, NeighborhoodGeoData]) => {
+      .then((response: [BlockGeoData, NeighborhoodGeoData, SiteGeoData]) => {
         dispatch(blockGeoData.loaded(response[0]));
         dispatch(neighborhoodGeoData.loaded(response[1]));
+        dispatch(siteGeoData.loaded(response[2]));
       })
       .catch((error: any) => {
         dispatch(blockGeoData.failed(error));
         dispatch(neighborhoodGeoData.failed(error));
+        dispatch(siteGeoData.failed(error));
       });
   };
 };

--- a/src/components/mapPageComponents/ducks/types.ts
+++ b/src/components/mapPageComponents/ducks/types.ts
@@ -46,11 +46,37 @@ interface NeighborhoodFeaturePropertiesResponse {
   lng: number;
 }
 
+// ---------------------------------Sites----------------------------------------
+
+export interface SiteGeoData {
+  type: string;
+  name: string;
+  features: SiteFeatureResponse[];
+}
+
+interface SiteFeatureResponse {
+  type: string;
+  properties: SiteFeaturePropertiesResponse;
+  geometry: MapGeometry;
+}
+
+interface SiteFeaturePropertiesResponse {
+  id: number;
+  treePresent: boolean;
+  diameter: number;
+  species: string;
+  updatedAt: string;
+  updatedBy: string;
+  address: string;
+  lat: number;
+  lng: number;
+}
+
 // ---------------------------------Shared Types----------------------------------------
 
 interface MapGeometry {
   type: string;
-  coordinates: Coordinate[][][];
+  coordinates: Coordinate[][][] | Coordinate;
 }
 
 type Coordinate = [number, number];
@@ -58,6 +84,7 @@ type Coordinate = [number, number];
 export interface MapGeoDataReducerState {
   readonly blockGeoData: AsyncRequest<BlockGeoData, any>;
   readonly neighborhoodGeoData: AsyncRequest<NeighborhoodGeoData, any>;
+  readonly siteGeoData: AsyncRequest<SiteGeoData, any>;
 }
 
 export type MapGeoDataThunkAction<R> = ThunkAction<

--- a/src/components/mapPageComponents/ducks/types.ts
+++ b/src/components/mapPageComponents/ducks/types.ts
@@ -73,6 +73,7 @@ interface SiteFeaturePropertiesResponse {
 }
 
 // ---------------------------------Shared Types----------------------------------------
+// These types follow the GeoJSON format: https://tools.ietf.org/html/rfc7946
 
 interface MapGeometry {
   type: string;
@@ -80,6 +81,8 @@ interface MapGeometry {
 }
 
 type Coordinate = [number, number];
+
+// ---------------------------------Redux----------------------------------------
 
 export interface MapGeoDataReducerState {
   readonly blockGeoData: AsyncRequest<BlockGeoData, any>;

--- a/src/components/mapPageComponents/mapPage/index.tsx
+++ b/src/components/mapPageComponents/mapPage/index.tsx
@@ -4,7 +4,7 @@ import MapView from '../mapView';
 import PageLayout from '../../pageLayout';
 import { Layout } from 'antd';
 import styled from 'styled-components';
-import { BlockGeoData, NeighborhoodGeoData } from '../ducks/types';
+import { BlockGeoData, NeighborhoodGeoData, SiteGeoData } from '../ducks/types';
 
 const { Content, Sider } = Layout;
 
@@ -15,6 +15,7 @@ const MainContent = styled.div`
 type MapPageProps = {
   readonly blocks: BlockGeoData;
   readonly neighborhoods: NeighborhoodGeoData;
+  readonly sites: SiteGeoData;
   readonly sidebarHeader: string;
   readonly sidebarDescription: string;
 };
@@ -22,6 +23,7 @@ type MapPageProps = {
 const MapPage: React.FC<MapPageProps> = ({
   blocks,
   neighborhoods,
+  sites,
   sidebarHeader,
   sidebarDescription,
   children,
@@ -30,7 +32,11 @@ const MapPage: React.FC<MapPageProps> = ({
     <MainContent>
       <PageLayout>
         <Content>
-          <MapView blocks={blocks} neighborhoods={neighborhoods} />
+          <MapView
+            blocks={blocks}
+            neighborhoods={neighborhoods}
+            sites={sites}
+          />
         </Content>
         <Sider width="20vw">
           <MapSidebar header={sidebarHeader} description={sidebarDescription}>

--- a/src/components/mapPageComponents/mapView/index.tsx
+++ b/src/components/mapPageComponents/mapView/index.tsx
@@ -3,7 +3,7 @@ import useWindowDimensions, { WindowTypes } from '../../windowDimensions';
 import { Input, message } from 'antd';
 import { Loader } from '@googlemaps/js-api-loader';
 import styled from 'styled-components';
-import { BlockGeoData, NeighborhoodGeoData } from '../ducks/types';
+import { BlockGeoData, NeighborhoodGeoData, SiteGeoData } from '../ducks/types';
 import ReservationModal, { ReservationModalType } from '../../reservationModal';
 import protectedApiClient from '../../../api/protectedApiClient';
 
@@ -31,9 +31,10 @@ const MapDiv = styled.div`
 interface MapViewProps {
   blocks: BlockGeoData;
   neighborhoods: NeighborhoodGeoData;
+  sites: SiteGeoData;
 }
 
-const MapView: React.FC<MapViewProps> = ({ blocks, neighborhoods }) => {
+const MapView: React.FC<MapViewProps> = ({ blocks, neighborhoods, sites }) => {
   // visibility of reservation modal
   const [showModal, setShowModal] = useState<boolean>(false);
   // block status for modal

--- a/src/components/mapPageComponents/mobileMapPage/index.tsx
+++ b/src/components/mapPageComponents/mobileMapPage/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Layout } from 'antd';
 import MapView from '../mapView';
 import PageLayout from '../../pageLayout';
-import { BlockGeoData, NeighborhoodGeoData } from '../ducks/types';
+import { BlockGeoData, NeighborhoodGeoData, SiteGeoData } from '../ducks/types';
 
 const { Content } = Layout;
 
@@ -14,18 +14,24 @@ const MainContent = styled.div`
 type MobileMapPageProps = {
   readonly blocks: BlockGeoData;
   readonly neighborhoods: NeighborhoodGeoData;
+  readonly sites: SiteGeoData;
 };
 
 const MobileMapPage: React.FC<MobileMapPageProps> = ({
   blocks,
   neighborhoods,
+  sites,
   children,
 }) => (
   <>
     <MainContent>
       <PageLayout>
         <Content>
-          <MapView blocks={blocks} neighborhoods={neighborhoods} />
+          <MapView
+            blocks={blocks}
+            neighborhoods={neighborhoods}
+            sites={sites}
+          />
         </Content>
         {children}
       </PageLayout>

--- a/src/containers/landing/index.tsx
+++ b/src/containers/landing/index.tsx
@@ -18,12 +18,14 @@ import { C4CState } from '../../store';
 interface LandingProps {
   readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
   readonly blocks: MapGeoDataReducerState['blockGeoData'];
+  readonly sites: MapGeoDataReducerState['siteGeoData'];
 }
 
 const mapStateToProps = (state: C4CState): LandingProps => {
   return {
     neighborhoods: state.mapGeoDataState.neighborhoodGeoData,
     blocks: state.mapGeoDataState.blockGeoData,
+    sites: state.mapGeoDataState.siteGeoData,
   };
 };
 
@@ -31,7 +33,7 @@ const PaddedContent = styled.div`
   padding: 24px 50px;
 `;
 
-const Landing: React.FC<LandingProps> = ({ neighborhoods, blocks }) => {
+const Landing: React.FC<LandingProps> = ({ neighborhoods, blocks, sites }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -56,10 +58,12 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, blocks }) => {
             />
           </Helmet>
           {asyncRequestIsComplete(blocks) &&
-            asyncRequestIsComplete(neighborhoods) && (
+            asyncRequestIsComplete(neighborhoods) &&
+            asyncRequestIsComplete(sites) && (
               <MobileMapPage
                 neighborhoods={neighborhoods.result}
                 blocks={blocks.result}
+                sites={sites.result}
               >
                 <PaddedContent>
                   <MobileLandingBar
@@ -91,10 +95,12 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, blocks }) => {
             />
           </Helmet>
           {asyncRequestIsComplete(blocks) &&
-            asyncRequestIsComplete(neighborhoods) && (
+            asyncRequestIsComplete(neighborhoods) &&
+            asyncRequestIsComplete(sites) && (
               <MapPage
                 neighborhoods={neighborhoods.result}
                 blocks={blocks.result}
+                sites={sites.result}
                 sidebarHeader={LANDING_TITLE}
                 sidebarDescription={LANDING_BODY}
               >

--- a/src/containers/reservations/index.tsx
+++ b/src/containers/reservations/index.tsx
@@ -21,18 +21,21 @@ const { Paragraph } = Typography;
 interface ReservationProps {
   readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
   readonly blocks: MapGeoDataReducerState['blockGeoData'];
+  readonly sites: MapGeoDataReducerState['siteGeoData'];
 }
 
 const mapStateToProps = (state: C4CState): ReservationProps => {
   return {
     neighborhoods: state.mapGeoDataState.neighborhoodGeoData,
     blocks: state.mapGeoDataState.blockGeoData,
+    sites: state.mapGeoDataState.siteGeoData,
   };
 };
 
 const Reservations: React.FC<ReservationProps> = ({
   neighborhoods,
   blocks,
+  sites,
 }) => {
   const dispatch = useDispatch();
 
@@ -54,10 +57,12 @@ const Reservations: React.FC<ReservationProps> = ({
             />
           </Helmet>
           {asyncRequestIsComplete(blocks) &&
-            asyncRequestIsComplete(neighborhoods) && (
+            asyncRequestIsComplete(neighborhoods) &&
+            asyncRequestIsComplete(sites) && (
               <MobileMapPage
                 blocks={blocks.result}
                 neighborhoods={neighborhoods.result}
+                sites={sites.result}
               >
                 <SlideDown>
                   <BlockTabs />
@@ -80,10 +85,12 @@ const Reservations: React.FC<ReservationProps> = ({
             />
           </Helmet>
           {asyncRequestIsComplete(blocks) &&
-            asyncRequestIsComplete(neighborhoods) && (
+            asyncRequestIsComplete(neighborhoods) &&
+            asyncRequestIsComplete(sites) && (
               <MapPage
                 blocks={blocks.result}
                 neighborhoods={neighborhoods.result}
+                sites={sites.result}
                 sidebarHeader={RESERVATION_TITLE}
                 sidebarDescription={RESERVATION_BODY}
               >


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/pulses/1247539229)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Connects get sites in geojson route so that site information can be used, ex. in displaying trees on the map.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Added route to ApiClientRoutes and tested successful request
- Added siteGeoData to the MapGeoDataReducerState, created necessary ducks, tested reducers and thunks
- Added sites to MapViewProps (setup for ticket to make the tree map)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Made sure unit tests passed