### PR TITLE
Add Validation and Feedback to Admin Forms

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -12,6 +12,7 @@ import {
   AuthRequest,
   ChangeEmailRequest,
   ChangePasswordRequest,
+  ChangePrivilegeRequest,
   ChangeUsernameRequest,
 } from '../components/forms/ducks/types';
 
@@ -43,11 +44,9 @@ export interface ProtectedApiClient {
     password: string;
   }) => Promise<void>;
   readonly deleteUser: (request: { password: string }) => Promise<void>;
-  readonly changePrivilegeLevel: (request: {
-    targetUserEmail: string;
-    newLevel: string;
-    password: string;
-  }) => Promise<void>;
+  readonly changePrivilegeLevel: (
+    request: ChangePrivilegeRequest,
+  ) => Promise<void>;
   readonly getUserData: () => Promise<UserData>;
   readonly createTeam: (request: CreateTeamRequest) => Promise<void>;
   readonly getTeams: () => Promise<TeamResponse[]>;
@@ -200,14 +199,10 @@ const deleteUser = (request: AuthRequest): Promise<void> => {
   return AppAxiosInstance.post(ProtectedApiClientRoutes.DELETE_USER, request);
 };
 
-const changePrivilegeLevel = (request: {
-  targetUserEmail: string;
-  newLevel: string;
-  password: string;
-}): Promise<void> => {
-  return AppAxiosInstance.post(AdminApiClientRoutes.CHANGE_PRIVILEGE, request)
-    .then((res) => res.data)
-    .catch((err) => err);
+const changePrivilegeLevel = (
+  request: ChangePrivilegeRequest,
+): Promise<void> => {
+  return AppAxiosInstance.post(AdminApiClientRoutes.CHANGE_PRIVILEGE, request);
 };
 
 const getUserData = (): Promise<UserData> => {

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1,11 +1,11 @@
 import ProtectedApiClient, {
-  ProtectedApiClientRoutes,
   AdminApiClientRoutes,
   ParameterizedApiRoutes,
+  ProtectedApiClientRoutes,
 } from '../protectedApiClient';
 import { TeamResponse, TeamRole } from '../../containers/teamPage/ducks/types';
 import nock from 'nock';
-import { UserData } from '../../auth/ducks/types';
+import { PrivilegeLevel, UserData } from '../../auth/ducks/types';
 
 const BASE_URL = 'http://localhost';
 
@@ -525,20 +525,6 @@ describe('Protected API Client Tests', () => {
     });
   });
 
-  describe('leaveTeam', () => {
-    it('makes the right request', async () => {
-      const response = '';
-
-      nock(BASE_URL)
-        .post(ParameterizedApiRoutes.LEAVE_TEAM(1))
-        .reply(200, response);
-
-      const result = await ProtectedApiClient.leaveTeam(1);
-
-      expect(result).toEqual(response);
-    });
-  });
-
   describe('disbandTeam', () => {
     it('makes the right request', async () => {
       const response = '';
@@ -573,17 +559,49 @@ describe('Protected API Client Tests', () => {
 describe('Admin Protected Client Routes', () => {
   describe('changePrivilegeLevel', () => {
     it('makes the right request', async () => {
-      const response = '';
+      const response = new Promise((res) => res);
 
       nock(BASE_URL)
         .post(AdminApiClientRoutes.CHANGE_PRIVILEGE)
         .reply(200, response);
 
-      const result = await ProtectedApiClient.changePrivilegeLevel({
+      const result = ProtectedApiClient.changePrivilegeLevel({
         targetUserEmail: 'jblanc222@gmail.com',
-        newLevel: 'STANDARD',
+        newLevel: PrivilegeLevel.STANDARD,
         password: 'password',
       });
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request, user already has privilege level', async () => {
+      const response = 'Given user already standard';
+
+      nock(BASE_URL)
+        .post(AdminApiClientRoutes.CHANGE_PRIVILEGE)
+        .reply(400, response);
+
+      const result = await ProtectedApiClient.changePrivilegeLevel({
+        targetUserEmail: 'jblanc222@gmail.com',
+        newLevel: PrivilegeLevel.STANDARD,
+        password: 'password',
+      }).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request, wrong password', async () => {
+      const response = 'Given password is not correct';
+
+      nock(BASE_URL)
+        .post(AdminApiClientRoutes.CHANGE_PRIVILEGE)
+        .reply(401, response);
+
+      const result = await ProtectedApiClient.changePrivilegeLevel({
+        targetUserEmail: 'jblanc222@gmail.com',
+        newLevel: PrivilegeLevel.STANDARD,
+        password: 'password',
+      }).catch((err) => err.response.data);
 
       expect(result).toEqual(response);
     });

--- a/src/components/forms/changePrivilegeForm/index.tsx
+++ b/src/components/forms/changePrivilegeForm/index.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Form, Input, message, Select } from 'antd';
+import ProtectedApiClient from '../../../api/protectedApiClient';
+import {
+  loginPasswordRules,
+  newLevelRules,
+  targetUserEmailRules,
+} from '../../../utils/formRules';
+import { ChangePrivilegeRequest } from '../ducks/types';
+import { SubmitButton } from '../../themedComponents';
+import styled from 'styled-components';
+import { SelectValue } from 'antd/lib/select';
+import { PrivilegeLevel } from '../../../auth/ducks/types';
+
+const { Option } = Select;
+
+const RoleDropdown = styled(Select)`
+  width: 100%;
+  height: 36px;
+`;
+
+interface ChangePrivilegeFormProps {
+  readonly privilegeLevel: PrivilegeLevel;
+}
+
+const ChangePrivilegeForm: React.FC<ChangePrivilegeFormProps> = ({
+  privilegeLevel,
+}) => {
+  const [changePrivilegeForm] = Form.useForm();
+
+  const onRoleChange = (role: SelectValue) => {
+    changePrivilegeForm.setFieldsValue({ newLevel: role });
+  };
+
+  const onFinishChangePrivilege = (values: ChangePrivilegeRequest) => {
+    ProtectedApiClient.changePrivilegeLevel(values)
+      .then(() => {
+        message.success('Privilege level changed!');
+        changePrivilegeForm.resetFields();
+      })
+      .catch((err) =>
+        message.error(
+          `Privilege level could not be changed: ${err.response.data}`,
+        ),
+      );
+  };
+
+  return (
+    <Form
+      name="changePrivilege"
+      form={changePrivilegeForm}
+      onFinish={onFinishChangePrivilege}
+    >
+      <Form.Item name="targetUserEmail" rules={targetUserEmailRules}>
+        <Input placeholder="User Email" />
+      </Form.Item>
+
+      <Form.Item name="newLevel" rules={newLevelRules}>
+        <RoleDropdown placeholder="New Role" onChange={onRoleChange}>
+          <Option value={'ADMIN'}>Admin</Option>
+          {privilegeLevel === PrivilegeLevel.SUPER_ADMIN && (
+            <>
+              <Option value={'STANDARD'}>Standard</Option>
+              <Option value={'SUPER_ADMIN'}>Super Admin</Option>
+            </>
+          )}
+        </RoleDropdown>
+      </Form.Item>
+
+      <Form.Item name="password" rules={loginPasswordRules}>
+        <Input.Password placeholder="Password" />
+      </Form.Item>
+
+      <SubmitButton type="primary" htmlType="submit">
+        Confirm
+      </SubmitButton>
+    </Form>
+  );
+};
+
+export default ChangePrivilegeForm;

--- a/src/components/forms/ducks/types.ts
+++ b/src/components/forms/ducks/types.ts
@@ -1,4 +1,4 @@
-import { SignupRequest } from '../../../auth/ducks/types';
+import { PrivilegeLevel, SignupRequest } from '../../../auth/ducks/types';
 
 export interface AuthRequest {
   readonly password: string;
@@ -23,4 +23,10 @@ export interface ChangePasswordFormValues extends ChangePasswordRequest {
 
 export interface SignupFormValues extends SignupRequest {
   readonly confirmPassword: string;
+}
+
+export interface ChangePrivilegeRequest {
+  readonly targetUserEmail: string;
+  readonly newLevel: PrivilegeLevel;
+  readonly password: string;
 }

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -1,15 +1,16 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
-import { Row, Typography, Select, Button, Form, Input } from 'antd';
+import { Typography } from 'antd';
 import PageHeader from '../../components/pageHeader';
 import PageLayout from '../../components/pageLayout';
 import styled from 'styled-components';
-import ProtectedApiClient from '../../api/protectedApiClient';
-import { FormInstance } from 'antd/lib/form';
-import { SelectValue } from 'antd/lib/select';
+import { useSelector } from 'react-redux';
+import { C4CState } from '../../store';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
+import ChangePrivilegeForm from '../../components/forms/changePrivilegeForm';
 
 const { Title } = Typography;
-const { Option } = Select;
 
 const AdminContentContainer = styled.div`
   margin: 100px auto auto;
@@ -21,31 +22,10 @@ const EditUser = styled.div`
   width: 370px;
 `;
 
-const RoleDropdown = styled(Select)`
-  width: 100%;
-  height: 36px;
-`;
-
 const AdminDashboard: React.FC = () => {
-  const isSuperAdmin = true;
-
-  const formRef = useRef<FormInstance>(null);
-
-  const onRoleChange = (role: SelectValue) => {
-    if (formRef.current !== null) {
-      formRef.current.setFieldsValue({ newLevel: role });
-    }
-  };
-
-  const onFinishChangePrivilege = (value: {
-    targetUserEmail: string;
-    newLevel: string;
-    password: string;
-  }) => {
-    ProtectedApiClient.changePrivilegeLevel(value)
-      .then((res) => res)
-      .catch((e) => e);
-  };
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
+    getPrivilegeLevel(state.authenticationState.tokens),
+  );
 
   return (
     <>
@@ -60,47 +40,10 @@ const AdminDashboard: React.FC = () => {
         <AdminContentContainer>
           <PageHeader pageTitle="Admin Dashboard" />
 
-          {isSuperAdmin && (
-            <EditUser>
-              <Row>
-                <Title level={4}>Edit Admins</Title>
-              </Row>
-
-              <Form
-                name="change-privilege"
-                onFinish={onFinishChangePrivilege}
-                ref={formRef}
-              >
-                <Form.Item name="targetUserEmail">
-                  <Input placeholder="User Email" />
-                </Form.Item>
-
-                <Form.Item name="newLevel">
-                  <RoleDropdown placeholder="New Role" onChange={onRoleChange}>
-                    <Option value="STANDARD">standard</Option>
-                    <Option value="ADMIN">admin</Option>
-                  </RoleDropdown>
-                </Form.Item>
-
-                <Form.Item name="password">
-                  <Input placeholder="Password" />
-                </Form.Item>
-
-                <Form.Item className="row">
-                  <Button type="primary" htmlType="submit">
-                    Confirm
-                  </Button>
-                </Form.Item>
-              </Form>
-            </EditUser>
-          )}
-
-          <Row>
-            <Title level={4}>Download All Team Data</Title>
-          </Row>
-          <Row className="row">
-            <Button type="primary">Download</Button>
-          </Row>
+          <EditUser>
+            <Title level={4}>Edit Admins</Title>
+            <ChangePrivilegeForm privilegeLevel={privilegeLevel} />
+          </EditUser>
         </AdminContentContainer>
       </PageLayout>
     </>

--- a/src/utils/formRules.tsx
+++ b/src/utils/formRules.tsx
@@ -5,6 +5,15 @@ export const enterEmailRules: Rule[] = [
   { type: 'email', message: 'Not a valid email address' },
 ];
 
+export const targetUserEmailRules: Rule[] = [
+  {
+    required: true,
+    message:
+      'Please input the email of the user whose privilege level you wish to change!',
+  },
+  { type: 'email', message: 'Not a valid email address' },
+];
+
 export const loginPasswordRules: Rule[] = [
   {
     required: true,
@@ -73,5 +82,12 @@ export const activitiesDateRules: Rule[] = [
   {
     required: true,
     message: 'Please input the date of the activity!',
+  },
+];
+
+export const newLevelRules: Rule[] = [
+  {
+    required: true,
+    message: 'Please pick a privilege level for this user!',
   },
 ];


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1258123891)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Adds validation and feedback to admin forms for a more user-friendly experience.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Created a separate component for the change privilege level form
  - admins can make other users admins (opened ticket for backend to prevent admins from demoting super admins)
  - super admins can make other users standard, admins, or super admins
- Removed catch in protectedApiClient so the error can be caught in the component and used to give feedback to the user
- Removed download team data button - team data won't be a feature in the next release of the site (revisit this in the fall)

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Admin Form
<img width="1680" alt="AdminOptions" src="https://user-images.githubusercontent.com/22990100/117238477-f643cd80-adfa-11eb-9777-3a5d3bfe17e1.png">

Super Admin Form
<img width="1680" alt="SuperAdminOptions" src="https://user-images.githubusercontent.com/22990100/117238485-f93ebe00-adfa-11eb-84e7-19a56dc73b8f.png">

Feedback Messages
<img width="1680" alt="Error" src="https://user-images.githubusercontent.com/22990100/117238501-ff349f00-adfa-11eb-9917-978391a06f6c.png">
<img width="1680" alt="Success" src="https://user-images.githubusercontent.com/22990100/117238507-0196f900-adfb-11eb-9eef-ac1aa5f663bc.png">

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Used form as an admin and super admin to change users' privilege levels, tested new change privilege level thunk.
