### PR TITLE
connecting stewardship and get site routes

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -34,7 +34,7 @@ export enum ApiClientRoutes {
   GET_ALL_SITES = '/api/v1/map/sites',
 }
 
-const baseSiteRoute = '/api/v1/protected/sites/';
+const baseSiteRoute = '/api/v1/sites/';
 
 export const ParameterizedApiRoutes = {
   GET_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}`, 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,7 +1,10 @@
 import AppAxiosInstance from '../auth/axios';
 import { VolunteerLeaderboardItem } from '../containers/volunteerLeaderboard/ducks/types';
 import { TeamLeaderboardItem } from '../containers/teamLeaderboard/ducks/types';
-import { StewardshipActivities, SiteProps } from '../containers/treePage/ducks/types';
+import {
+  StewardshipActivities,
+  SiteProps,
+} from '../containers/treePage/ducks/types';
 import {
   BlockGeoData,
   NeighborhoodGeoData,
@@ -23,7 +26,9 @@ export interface ApiClient {
   readonly getNeighborhoodGeoData: () => Promise<NeighborhoodGeoData>;
   readonly getSiteGeoData: () => Promise<SiteGeoData>;
   readonly getSite: (siteId: number) => Promise<SiteProps>;
-  readonly getStewardshipActivities: (siteId: number) => Promise<StewardshipActivities>;
+  readonly getStewardshipActivities: (
+    siteId: number,
+  ) => Promise<StewardshipActivities>;
 }
 
 export enum ApiClientRoutes {
@@ -37,9 +42,10 @@ export enum ApiClientRoutes {
 const baseSiteRoute = '/api/v1/sites/';
 
 export const ParameterizedApiRoutes = {
-  GET_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}`, 
-  GET_STEWARSHIP_ACTIVITIES: (siteId: number): string => `${baseSiteRoute}${siteId}/stewardship_activities`, 
-}
+  GET_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}`,
+  GET_STEWARSHIP_ACTIVITIES: (siteId: number): string =>
+    `${baseSiteRoute}${siteId}/stewardship_activities`,
+};
 
 const getUsersLeaderboard = (
   previousDays: number | null,
@@ -79,13 +85,17 @@ const getSite = (siteId: number): Promise<SiteProps> => {
   return AppAxiosInstance.get(ParameterizedApiRoutes.GET_SITE(siteId))
     .then((r) => r.data)
     .catch((e) => e);
-}
+};
 
-const getStewardshipActivities = (siteId: number): Promise<StewardshipActivities> => {
-  return AppAxiosInstance.get(ParameterizedApiRoutes.GET_STEWARSHIP_ACTIVITIES(siteId))
+const getStewardshipActivities = (
+  siteId: number,
+): Promise<StewardshipActivities> => {
+  return AppAxiosInstance.get(
+    ParameterizedApiRoutes.GET_STEWARSHIP_ACTIVITIES(siteId),
+  )
     .then((r) => r.data)
     .catch((e) => e);
-}
+};
 
 const Client: ApiClient = Object.freeze({
   getUsersLeaderboard,

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,6 +1,7 @@
 import AppAxiosInstance from '../auth/axios';
 import { VolunteerLeaderboardItem } from '../containers/volunteerLeaderboard/ducks/types';
 import { TeamLeaderboardItem } from '../containers/teamLeaderboard/ducks/types';
+import { StewardshipActivities, SiteProps } from '../containers/treePage/ducks/types';
 import {
   BlockGeoData,
   NeighborhoodGeoData,
@@ -21,6 +22,8 @@ export interface ApiClient {
   readonly getBlockGeoData: () => Promise<BlockGeoData>;
   readonly getNeighborhoodGeoData: () => Promise<NeighborhoodGeoData>;
   readonly getSiteGeoData: () => Promise<SiteGeoData>;
+  readonly getSite: (siteId: number) => Promise<SiteProps>;
+  readonly getStewardshipActivities: (siteId: number) => Promise<StewardshipActivities>;
 }
 
 export enum ApiClientRoutes {
@@ -29,6 +32,13 @@ export enum ApiClientRoutes {
   GET_ALL_BLOCKS = '/api/v1/map/blocks',
   GET_ALL_NEIGHBORHOODS = '/api/v1/map/neighborhoods',
   GET_ALL_SITES = '/api/v1/map/sites',
+}
+
+const baseSiteRoute = '/api/v1/protected/sites/';
+
+export const ParameterizedApiRoutes = {
+  GET_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}`, 
+  GET_STEWARSHIP_ACTIVITIES: (siteId: number): string => `${baseSiteRoute}${siteId}/stewardship_activities`, 
 }
 
 const getUsersLeaderboard = (
@@ -65,12 +75,26 @@ const getSiteGeoData = (): Promise<SiteGeoData> => {
     .catch((err) => err);
 };
 
+const getSite = (siteId: number): Promise<SiteProps> => {
+  return AppAxiosInstance.get(ParameterizedApiRoutes.GET_SITE(siteId))
+    .then((r) => r.data)
+    .catch((e) => e);
+}
+
+const getStewardshipActivities = (siteId: number): Promise<StewardshipActivities> => {
+  return AppAxiosInstance.get(ParameterizedApiRoutes.GET_STEWARSHIP_ACTIVITIES(siteId))
+    .then((r) => r.data)
+    .catch((e) => e);
+}
+
 const Client: ApiClient = Object.freeze({
   getUsersLeaderboard,
   getTeamsLeaderboard,
   getBlockGeoData,
   getNeighborhoodGeoData,
   getSiteGeoData,
+  getSite,
+  getStewardshipActivities,
 });
 
 export default Client;

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -14,7 +14,10 @@ import {
   ChangePasswordRequest,
   ChangeUsernameRequest,
 } from '../components/forms/ducks/types';
-import { ActivityRequest, AdoptedSites } from '../containers/treePage/ducks/types';
+import {
+  ActivityRequest,
+  AdoptedSites,
+} from '../containers/treePage/ducks/types';
 
 export interface ProtectedApiExtraArgs {
   readonly protectedApiClient: ProtectedApiClient;
@@ -72,7 +75,10 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly adoptSite: (siteId: number) => Promise<void>;
   readonly unadoptSite: (siteId: number) => Promise<void>;
-  readonly recordStewardship: (siteId: number, request: ActivityRequest) => Promise<void>;
+  readonly recordStewardship: (
+    siteId: number,
+    request: ActivityRequest,
+  ) => Promise<void>;
   readonly deleteStewardship: (activityId: number) => Promise<void>;
   readonly getAdoptedSites: () => Promise<AdoptedSites>;
 }
@@ -122,9 +128,11 @@ export const ParameterizedApiRoutes = {
   TRANSFER_OWNERSHIP: (teamId: number): string =>
     `${baseTeamRoute}${teamId}/transfer_ownership`,
   ADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/adopt`,
-  UNADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/unadopt`,  
-  RECORD_STEWARDSHIP: (siteId: number): string => `${baseSiteRoute}${siteId}/record_stewardship`, 
-  DELETE_STEWARDSHIP: (actvityId: number): string => `${baseSiteRoute}remove_stewardship/${actvityId}`, 
+  UNADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/unadopt`,
+  RECORD_STEWARDSHIP: (siteId: number): string =>
+    `${baseSiteRoute}${siteId}/record_stewardship`,
+  DELETE_STEWARDSHIP: (actvityId: number): string =>
+    `${baseSiteRoute}remove_stewardship/${actvityId}`,
 };
 
 const makeReservation = (blockId: number, teamId?: number): Promise<void> => {
@@ -332,25 +340,17 @@ const transferOwnership = (
     .catch((err) => err);
 };
 
-const adoptSite = (
-  siteId: number
-): Promise<void> => {
-  return AppAxiosInstance.post(
-    ParameterizedApiRoutes.ADOPT_SITE(siteId),
-  )
+const adoptSite = (siteId: number): Promise<void> => {
+  return AppAxiosInstance.post(ParameterizedApiRoutes.ADOPT_SITE(siteId))
     .then((res) => res.data)
     .catch((err) => err);
-}
+};
 
-const unadoptSite = (
-  siteId: number
-): Promise<void> => {
-  return AppAxiosInstance.post(
-    ParameterizedApiRoutes.UNADOPT_SITE(siteId),
-  )
+const unadoptSite = (siteId: number): Promise<void> => {
+  return AppAxiosInstance.post(ParameterizedApiRoutes.UNADOPT_SITE(siteId))
     .then((res) => res.data)
     .catch((err) => err);
-}
+};
 
 const recordStewardship = (
   siteId: number,
@@ -358,29 +358,25 @@ const recordStewardship = (
 ): Promise<void> => {
   return AppAxiosInstance.post(
     ParameterizedApiRoutes.RECORD_STEWARDSHIP(siteId),
-    request
+    request,
   )
     .then((res) => res.data)
     .catch((err) => err);
-}
+};
 
-const deleteStewardship = (
-  siteId: number
-): Promise<void> => {
+const deleteStewardship = (siteId: number): Promise<void> => {
   return AppAxiosInstance.post(
     ParameterizedApiRoutes.DELETE_STEWARDSHIP(siteId),
   )
     .then((res) => res.data)
     .catch((err) => err);
-}
+};
 
 const getAdoptedSites = (): Promise<AdoptedSites> => {
-  return AppAxiosInstance.get(
-    ProtectedApiClientRoutes.GET_ADOPTED_SITES,
-  )
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.GET_ADOPTED_SITES)
     .then((res) => res.data)
     .catch((err) => err);
-}
+};
 
 const Client: ProtectedApiClient = Object.freeze({
   makeReservation,

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -14,6 +14,7 @@ import {
   ChangePasswordRequest,
   ChangeUsernameRequest,
 } from '../components/forms/ducks/types';
+import { AdoptedSites } from '../containers/treePage/ducks/types';
 
 export interface ProtectedApiExtraArgs {
   readonly protectedApiClient: ProtectedApiClient;
@@ -69,6 +70,11 @@ export interface ProtectedApiClient {
     teamId: number,
     request: TransferOwnershipRequest,
   ) => Promise<void>;
+  readonly adoptSite: (siteId: number) => Promise<void>;
+  readonly unadoptSite: (siteId: number) => Promise<void>;
+  readonly recordStewardship: (siteId: number) => Promise<void>;
+  readonly deleteStewardship: (activityId: number) => Promise<void>;
+  readonly getAdoptedSites: () => Promise<AdoptedSites>;
 }
 
 export enum ProtectedApiClientRoutes {
@@ -82,6 +88,7 @@ export enum ProtectedApiClientRoutes {
   GET_USER_DATA = '/api/v1/protected/user/data',
   CREATE_TEAM = '/api/v1/protected/teams/create',
   GET_TEAMS = '/api/v1/protected/teams/',
+  GET_ADOPTED_SITES = '/api/v1/protected/sites/adopted_sites',
 }
 
 export enum AdminApiClientRoutes {
@@ -93,6 +100,7 @@ export enum AdminApiClientRoutes {
 }
 
 const baseTeamRoute = '/api/v1/protected/teams/';
+const baseSiteRoute = '/api/v1/protected/sites/';
 
 export const ParameterizedApiRoutes = {
   GET_TEAM: (teamId: number): string => `${baseTeamRoute}${teamId}`,
@@ -113,6 +121,10 @@ export const ParameterizedApiRoutes = {
   DISBAND_TEAM: (teamId: number): string => `${baseTeamRoute}${teamId}/disband`,
   TRANSFER_OWNERSHIP: (teamId: number): string =>
     `${baseTeamRoute}${teamId}/transfer_ownership`,
+  ADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/adopt`,
+  UNADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/unadopt`,  
+  RECORD_STEWARDSHIP: (siteId: number): string => `${baseSiteRoute}${siteId}/record_stewardship`, 
+  DELETE_STEWARDSHIP: (actvityId: number): string => `${baseSiteRoute}remove_stewardship/${actvityId}`, 
 };
 
 const makeReservation = (blockId: number, teamId?: number): Promise<void> => {
@@ -320,6 +332,54 @@ const transferOwnership = (
     .catch((err) => err);
 };
 
+const adoptSite = (
+  siteId: number
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.ADOPT_SITE(siteId),
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+}
+
+const unadoptSite = (
+  siteId: number
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.UNADOPT_SITE(siteId),
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+}
+
+const recordStewardship = (
+  siteId: number
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.RECORD_STEWARDSHIP(siteId),
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+}
+
+const deleteStewardship = (
+  siteId: number
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.DELETE_STEWARDSHIP(siteId),
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+}
+
+const getAdoptedSites = (): Promise<AdoptedSites> => {
+  return AppAxiosInstance.get(
+    ProtectedApiClientRoutes.GET_ADOPTED_SITES,
+  )
+    .then((res) => res.data)
+    .catch((err) => err);
+}
+
 const Client: ProtectedApiClient = Object.freeze({
   makeReservation,
   completeReservation,
@@ -348,6 +408,11 @@ const Client: ProtectedApiClient = Object.freeze({
   leaveTeam,
   disbandTeam,
   transferOwnership,
+  adoptSite,
+  unadoptSite,
+  recordStewardship,
+  deleteStewardship,
+  getAdoptedSites,
 });
 
 export default Client;

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -14,7 +14,7 @@ import {
   ChangePasswordRequest,
   ChangeUsernameRequest,
 } from '../components/forms/ducks/types';
-import { AdoptedSites } from '../containers/treePage/ducks/types';
+import { ActivityRequest, AdoptedSites } from '../containers/treePage/ducks/types';
 
 export interface ProtectedApiExtraArgs {
   readonly protectedApiClient: ProtectedApiClient;
@@ -72,7 +72,7 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly adoptSite: (siteId: number) => Promise<void>;
   readonly unadoptSite: (siteId: number) => Promise<void>;
-  readonly recordStewardship: (siteId: number) => Promise<void>;
+  readonly recordStewardship: (siteId: number, request: ActivityRequest) => Promise<void>;
   readonly deleteStewardship: (activityId: number) => Promise<void>;
   readonly getAdoptedSites: () => Promise<AdoptedSites>;
 }
@@ -353,10 +353,12 @@ const unadoptSite = (
 }
 
 const recordStewardship = (
-  siteId: number
+  siteId: number,
+  request: ActivityRequest,
 ): Promise<void> => {
   return AppAxiosInstance.post(
     ParameterizedApiRoutes.RECORD_STEWARDSHIP(siteId),
+    request
   )
     .then((res) => res.data)
     .catch((err) => err);

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -341,15 +341,15 @@ const transferOwnership = (
 };
 
 const adoptSite = (siteId: number): Promise<void> => {
-  return AppAxiosInstance.post(ParameterizedApiRoutes.ADOPT_SITE(siteId))
-    .then((res) => res.data)
-    .catch((err) => err);
+  return AppAxiosInstance.post(ParameterizedApiRoutes.ADOPT_SITE(siteId)).then(
+    (res) => res.data,
+  );
 };
 
 const unadoptSite = (siteId: number): Promise<void> => {
-  return AppAxiosInstance.post(ParameterizedApiRoutes.UNADOPT_SITE(siteId))
-    .then((res) => res.data)
-    .catch((err) => err);
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.UNADOPT_SITE(siteId),
+  ).then((res) => res.data);
 };
 
 const recordStewardship = (
@@ -359,9 +359,7 @@ const recordStewardship = (
   return AppAxiosInstance.post(
     ParameterizedApiRoutes.RECORD_STEWARDSHIP(siteId),
     request,
-  )
-    .then((res) => res.data)
-    .catch((err) => err);
+  ).then((res) => res.data);
 };
 
 const deleteStewardship = (siteId: number): Promise<void> => {

--- a/src/api/test/apiClient.test.ts
+++ b/src/api/test/apiClient.test.ts
@@ -3,7 +3,10 @@ import {
   NeighborhoodGeoData,
   SiteGeoData,
 } from '../../components/mapPageComponents/ducks/types';
-import ApiClient, { ApiClientRoutes } from '../apiClient';
+import ApiClient, {
+  ApiClientRoutes,
+  ParameterizedApiRoutes,
+} from '../apiClient';
 import nock from 'nock';
 
 const BASE_URL = 'http://localhost';
@@ -117,6 +120,78 @@ describe('Authentication Client Tests', () => {
 
         expect(result).toEqual(response);
       });
+    });
+  });
+
+  describe('Get a site', () => {
+    it('makes the right request', async () => {
+      const response = {
+        siteId: 1000,
+        blockId: 10,
+        lat: 1,
+        lng: 1,
+        city: 'Boston',
+        zip: '02115',
+        address: '1000 boston ave',
+        entries: [
+          {
+            id: 1,
+            username: 'will',
+            updatedAt: 10000000,
+            treePresent: true,
+            genus: 'bad',
+          },
+          {
+            id: 1,
+            username: 'will',
+            updatedAt: 1000000,
+            treePresent: false,
+          },
+        ],
+      };
+
+      nock(BASE_URL)
+        .get(ParameterizedApiRoutes.GET_SITE(1000))
+        .reply(200, response);
+
+      const result = await ApiClient.getSite(1000);
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('Get stewardship activities', () => {
+    it('makes the right request', async () => {
+      const response = {
+        activities: [
+          {
+            id: 3,
+            userId: 'will',
+            date: 100000,
+            watered: true,
+            mulched: false,
+            cleaned: false,
+            weeded: true,
+          },
+          {
+            id: 2,
+            userId: 'will',
+            date: 10000,
+            watered: false,
+            mulched: false,
+            cleaned: true,
+            weeded: true,
+          },
+        ],
+      };
+
+      nock(BASE_URL)
+        .get(ParameterizedApiRoutes.GET_STEWARSHIP_ACTIVITIES(1000))
+        .reply(200, response);
+
+      const result = await ApiClient.getStewardshipActivities(1000);
+
+      expect(result).toEqual(response);
     });
   });
 });

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -568,6 +568,72 @@ describe('Protected API Client Tests', () => {
       expect(result).toEqual(response);
     });
   });
+
+  // Site tests
+  describe('Adopt a site', () => {
+    it('makes the right request', async () => {
+      const response = '';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.ADOPT_SITE(1))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.adoptSite(1);
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('Unadopt a site', () => {
+    it('makes the right request', async () => {
+      const response = '';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.UNADOPT_SITE(1))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.unadoptSite(1);
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('Get adopted sites', () => {
+    it('makes the right request', async () => {
+      const response = {
+        adoptedSites: [1, 2, 3],
+      };
+
+      nock(BASE_URL)
+        .get(ProtectedApiClientRoutes.GET_ADOPTED_SITES)
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.getAdoptedSites();
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  // Site tests
+  describe('Adopt a site', () => {
+    it('makes the right request', async () => {
+      const response = '';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.RECORD_STEWARDSHIP(1))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.recordStewardship(1, {
+        date: '10/12/2020',
+        watered: true,
+        mulched: false,
+        cleaned: true,
+        weeded: false,
+      });
+
+      expect(result).toEqual(response);
+    });
+  });
 });
 
 describe('Admin Protected Client Routes', () => {

--- a/src/components/stewardshipForm/index.tsx
+++ b/src/components/stewardshipForm/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { Button, Form, Checkbox, Typography, DatePicker } from 'antd';
+import { Button, Form, Checkbox, Typography, DatePicker, FormInstance } from 'antd';
 import styled from 'styled-components';
 import { activitiesDateRules, activitiesRules } from '../../utils/formRules';
 
@@ -19,9 +19,10 @@ interface StewardshipFormProps {
     activityDate: moment.Moment;
     stewardshipActivities: string[];
   }) => void;
+  form: FormInstance;
 }
 
-const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish }) => {
+const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish, form }) => {
   const stewardshipOptions = [
     'Watered',
     'Mulched',
@@ -31,13 +32,18 @@ const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish }) => {
 
   return (
     <>
-      <Form name="recordStewardship" onFinish={onFinish}>
+      <Form 
+      name="recordStewardship" 
+      onFinish={onFinish}
+      form={form}
+      initialValues={{ activityDate: moment()}}
+      >
         <ItemLabel>Activity Date</ItemLabel>
         <Form.Item name="activityDate" rules={activitiesDateRules}>
-          <TreeDatePicker defaultValue={moment()} format={'MM/DD/YYYY'} />
+          <TreeDatePicker format={'MM/DD/YYYY'} />
         </Form.Item>
         <ItemLabel>Stewardship Activites</ItemLabel>
-        <Form.Item name="stewardshipActivites" rules={activitiesRules}>
+        <Form.Item name="stewardshipActivities" rules={activitiesRules}>
           <Checkbox.Group options={stewardshipOptions} />
         </Form.Item>
         <Form.Item>

--- a/src/components/stewardshipForm/index.tsx
+++ b/src/components/stewardshipForm/index.tsx
@@ -14,7 +14,14 @@ const TreeDatePicker = styled(DatePicker)`
   width: 50%;
 `;
 
-const StewardshipForm: React.FC = () => {
+interface StewardshipFormProps {
+  onFinish: (values: {
+    activityDate: moment.Moment;
+    stewardshipActivities: string[];
+  }) => void;
+}
+
+const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish }) => {
   const stewardshipOptions = [
     'Watered',
     'Mulched',
@@ -22,16 +29,9 @@ const StewardshipForm: React.FC = () => {
     'Cleared Waste & Litter',
   ];
 
-  const onFinishRecordStewardship = (values: {
-    activityDate: moment.Moment;
-    stewardshipActivities: string[];
-  }) => {
-    /*Placeholder */
-  };
-
   return (
     <>
-      <Form name="recordStewardship" onFinish={onFinishRecordStewardship}>
+      <Form name="recordStewardship" onFinish={onFinish}>
         <ItemLabel>Activity Date</ItemLabel>
         <Form.Item name="activityDate" rules={activitiesDateRules}>
           <TreeDatePicker defaultValue={moment()} format={'MM/DD/YYYY'} />

--- a/src/components/stewardshipForm/index.tsx
+++ b/src/components/stewardshipForm/index.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import moment from 'moment';
-import { Button, Form, Checkbox, Typography, DatePicker, FormInstance } from 'antd';
+import {
+  Button,
+  Form,
+  Checkbox,
+  Typography,
+  DatePicker,
+  FormInstance,
+} from 'antd';
 import styled from 'styled-components';
 import { activitiesDateRules, activitiesRules } from '../../utils/formRules';
 
@@ -22,7 +29,10 @@ interface StewardshipFormProps {
   form: FormInstance;
 }
 
-const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish, form }) => {
+const StewardshipForm: React.FC<StewardshipFormProps> = ({
+  onFinish,
+  form,
+}) => {
   const stewardshipOptions = [
     'Watered',
     'Mulched',
@@ -32,11 +42,11 @@ const StewardshipForm: React.FC<StewardshipFormProps> = ({ onFinish, form }) => 
 
   return (
     <>
-      <Form 
-      name="recordStewardship" 
-      onFinish={onFinish}
-      form={form}
-      initialValues={{ activityDate: moment()}}
+      <Form
+        name="recordStewardship"
+        onFinish={onFinish}
+        form={form}
+        initialValues={{ activityDate: moment() }}
       >
         <ItemLabel>Activity Date</ItemLabel>
         <Form.Item name="activityDate" rules={activitiesDateRules}>

--- a/src/containers/treePage/ducks/actions.ts
+++ b/src/containers/treePage/ducks/actions.ts
@@ -3,7 +3,10 @@ import { SiteProps, StewardshipActivities, AdoptedSites } from './types';
 
 export const siteData = genericAsyncActions<SiteProps, any>();
 
-export const stewardshipActivities = genericAsyncActions<StewardshipActivities, any>();
+export const stewardshipActivities = genericAsyncActions<
+  StewardshipActivities,
+  any
+>();
 
 export const adoptedSites = genericAsyncActions<AdoptedSites, any>();
 
@@ -18,4 +21,4 @@ export type SiteActions =
 export type ProtectedSiteActions =
   | ReturnType<typeof adoptedSites.loading>
   | ReturnType<typeof adoptedSites.loaded>
-  | ReturnType<typeof adoptedSites.failed>;  
+  | ReturnType<typeof adoptedSites.failed>;

--- a/src/containers/treePage/ducks/actions.ts
+++ b/src/containers/treePage/ducks/actions.ts
@@ -1,0 +1,21 @@
+import { genericAsyncActions } from '../../../utils/asyncRequest';
+import { SiteProps, StewardshipActivities, AdoptedSites } from './types';
+
+export const siteData = genericAsyncActions<SiteProps, any>();
+
+export const stewardshipActivities = genericAsyncActions<StewardshipActivities, any>();
+
+export const adoptedSites = genericAsyncActions<AdoptedSites, any>();
+
+export type SiteActions =
+  | ReturnType<typeof siteData.loading>
+  | ReturnType<typeof siteData.loaded>
+  | ReturnType<typeof siteData.failed>
+  | ReturnType<typeof stewardshipActivities.loading>
+  | ReturnType<typeof stewardshipActivities.loaded>
+  | ReturnType<typeof stewardshipActivities.failed>;
+
+export type ProtectedSiteActions =
+  | ReturnType<typeof adoptedSites.loading>
+  | ReturnType<typeof adoptedSites.loaded>
+  | ReturnType<typeof adoptedSites.failed>;  

--- a/src/containers/treePage/ducks/protectedReducer.ts
+++ b/src/containers/treePage/ducks/protectedReducer.ts
@@ -1,0 +1,39 @@
+import { ProtectedSitesReducerState, AdoptedSites } from './types';
+import {
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+} from '../../../utils/asyncRequest';
+import { adoptedSites } from './actions';
+import { C4CAction } from '../../../store';
+
+export const initialProtectedSiteState: ProtectedSitesReducerState = {
+  adoptedSites: AsyncRequestNotStarted<AdoptedSites, any>(),
+};
+
+const adoptedSitesReducer = generateAsyncRequestReducer<
+  ProtectedSitesReducerState,
+  AdoptedSites,
+  void
+>(adoptedSites.key);
+
+const reducers = (
+  state: ProtectedSitesReducerState = initialProtectedSiteState,
+  action: C4CAction,
+): ProtectedSitesReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        adoptedSites: adoptedSitesReducer(state.adoptedSites, action),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/treePage/ducks/reducer.ts
+++ b/src/containers/treePage/ducks/reducer.ts
@@ -37,7 +37,10 @@ const reducers = (
       return {
         ...state,
         siteData: siteDataReducer(state.siteData, action),
-        stewarshipActivityData: stewarshipActivityReducer(state.stewarshipActivityData, action),
+        stewarshipActivityData: stewarshipActivityReducer(
+          state.stewarshipActivityData,
+          action,
+        ),
       };
     default:
       return state;

--- a/src/containers/treePage/ducks/reducer.ts
+++ b/src/containers/treePage/ducks/reducer.ts
@@ -1,0 +1,47 @@
+import { SiteReducerState, StewardshipActivities, SiteProps } from './types';
+import {
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+} from '../../../utils/asyncRequest';
+import { siteData, stewardshipActivities } from './actions';
+import { C4CAction } from '../../../store';
+
+export const initialSiteState: SiteReducerState = {
+  siteData: AsyncRequestNotStarted<SiteProps, any>(),
+  stewarshipActivityData: AsyncRequestNotStarted<StewardshipActivities, any>(),
+};
+
+const siteDataReducer = generateAsyncRequestReducer<
+  SiteReducerState,
+  SiteProps,
+  void
+>(siteData.key);
+
+const stewarshipActivityReducer = generateAsyncRequestReducer<
+  SiteReducerState,
+  StewardshipActivities,
+  void
+>(stewardshipActivities.key);
+
+const reducers = (
+  state: SiteReducerState = initialSiteState,
+  action: C4CAction,
+): SiteReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        siteData: siteDataReducer(state.siteData, action),
+        stewarshipActivityData: stewarshipActivityReducer(state.stewarshipActivityData, action),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -1,0 +1,30 @@
+import { asyncRequestIsComplete, AsyncRequest } from '../../../utils/asyncRequest';
+import { StewardshipActivities, AdoptedSites, TreeCare } from './types';
+
+export const mapStewardshipToTreeCare = (
+  items: AsyncRequest<StewardshipActivities, any>,
+): TreeCare[] => {
+  if (asyncRequestIsComplete(items)) {
+    return items.result.activities.map((item) => {
+      const month = item.date.toLocaleString('default', { month: 'long' });
+      const day = item.date.getDate();
+
+      return {
+        date: `${month} ${day}th`,
+        message: `Was ${item.cleaned && "cleared of waste and "}${item.mulched && "mulched and "}${item.watered && "watered and "}${item.weeded && "weeded"}.`
+      };
+    });
+  }
+  return [];
+};
+
+export const isTreeAdopted = (
+  items: AsyncRequest<AdoptedSites, any>,
+  siteId: number
+): boolean => {
+  if (asyncRequestIsComplete(items)) {
+    return items.result.adoptedSites.includes(siteId);
+  } else {
+    return false;
+  }
+}

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -1,17 +1,35 @@
-import { asyncRequestIsComplete, AsyncRequest } from '../../../utils/asyncRequest';
-import { StewardshipActivities, AdoptedSites, TreeCare, SiteProps, Entry, SiteEntryNames } from './types';
+import {
+  asyncRequestIsComplete,
+  AsyncRequest,
+} from '../../../utils/asyncRequest';
+import {
+  StewardshipActivities,
+  AdoptedSites,
+  TreeCare,
+  SiteProps,
+  Entry,
+  SiteEntryNames,
+} from './types';
 
 export const mapStewardshipToTreeCare = (
   items: AsyncRequest<StewardshipActivities, any>,
 ): TreeCare[] => {
   if (asyncRequestIsComplete(items)) {
     return items.result.stewardshipActivities.map((item) => {
-      const month = item.date.toLocaleString('default', { month: 'long' });
-      const day = item.date.getDate();
+      const month = new Date(item.date).toLocaleString('default', {
+        month: 'long',
+      });
+      const day = new Date(item.date).getDate();
 
+      const activityStrings = [];
+      // These cause linting errors for some reason
+      if (item.cleaned) activityStrings.push('cleared of waste');
+      if (item.mulched) activityStrings.push('mulched');
+      if (item.watered) activityStrings.push('watered');
+      if (item.weeded) activityStrings.push('weeded');
       return {
         date: `${month} ${day}th`,
-        message: `Was ${item.cleaned && "cleared of waste and "}${item.mulched && "mulched and "}${item.watered && "watered and "}${item.weeded && "weeded"}.`
+        message: `Was ${activityStrings.join(' and ')}.`,
       };
     });
   }
@@ -22,26 +40,29 @@ export const getLatestEntry = (
   items: AsyncRequest<SiteProps, any>,
 ): Entry[] => {
   if (asyncRequestIsComplete(items)) {
-    return Object.entries(items.result.entries[0]).reduce<Entry[]>((soFar, [key, value]) => {
-      if(SiteEntryNames[key] && value !== null) {
-        soFar.push({
-          title: SiteEntryNames[key],
-          value: value.toString()
-        });
-      }
-      return soFar;
-    }, [])
+    return Object.entries(items.result.entries[0]).reduce<Entry[]>(
+      (soFar, [key, value]) => {
+        if (SiteEntryNames[key] && value !== null) {
+          soFar.push({
+            title: SiteEntryNames[key],
+            value: value.toString(),
+          });
+        }
+        return soFar;
+      },
+      [],
+    );
   }
-  return []
-}
+  return [];
+};
 
 export const isTreeAdopted = (
   items: AsyncRequest<AdoptedSites, any>,
-  siteId: number
+  siteId: number,
 ): boolean => {
   if (asyncRequestIsComplete(items)) {
     return items.result.adoptedSites.includes(siteId);
   } else {
     return false;
   }
-}
+};

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -1,11 +1,11 @@
 import { asyncRequestIsComplete, AsyncRequest } from '../../../utils/asyncRequest';
-import { StewardshipActivities, AdoptedSites, TreeCare } from './types';
+import { StewardshipActivities, AdoptedSites, TreeCare, SiteProps, Entry, SiteEntryNames } from './types';
 
 export const mapStewardshipToTreeCare = (
   items: AsyncRequest<StewardshipActivities, any>,
 ): TreeCare[] => {
   if (asyncRequestIsComplete(items)) {
-    return items.result.activities.map((item) => {
+    return items.result.stewardshipActivities.map((item) => {
       const month = item.date.toLocaleString('default', { month: 'long' });
       const day = item.date.getDate();
 
@@ -17,6 +17,23 @@ export const mapStewardshipToTreeCare = (
   }
   return [];
 };
+
+export const getLatestEntry = (
+  items: AsyncRequest<SiteProps, any>,
+): Entry[] => {
+  if (asyncRequestIsComplete(items)) {
+    return Object.entries(items.result.entries[0]).reduce<Entry[]>((soFar, [key, value]) => {
+      if(SiteEntryNames[key] && value !== null) {
+        soFar.push({
+          title: SiteEntryNames[key],
+          value: value.toString()
+        });
+      }
+      return soFar;
+    }, [])
+  }
+  return []
+}
 
 export const isTreeAdopted = (
   items: AsyncRequest<AdoptedSites, any>,

--- a/src/containers/treePage/ducks/thunks.ts
+++ b/src/containers/treePage/ducks/thunks.ts
@@ -4,7 +4,6 @@ import {
   AdoptedSites,
   SiteReducerThunkAction,
   ProtectedSiteReducerThunkAction,
-  ActivityRequest,
 } from './types';
 import { siteData, stewardshipActivities, adoptedSites } from './actions';
 import protectedApiClient from '../../../api/protectedApiClient';

--- a/src/containers/treePage/ducks/thunks.ts
+++ b/src/containers/treePage/ducks/thunks.ts
@@ -1,4 +1,11 @@
-import { SiteProps, StewardshipActivities, AdoptedSites, SiteReducerThunkAction, ProtectedSiteReducerThunkAction, ActivityRequest } from './types';
+import {
+  SiteProps,
+  StewardshipActivities,
+  AdoptedSites,
+  SiteReducerThunkAction,
+  ProtectedSiteReducerThunkAction,
+  ActivityRequest,
+} from './types';
 import { siteData, stewardshipActivities, adoptedSites } from './actions';
 import protectedApiClient from '../../../api/protectedApiClient';
 

--- a/src/containers/treePage/ducks/thunks.ts
+++ b/src/containers/treePage/ducks/thunks.ts
@@ -1,5 +1,6 @@
 import { SiteProps, StewardshipActivities, AdoptedSites, SiteReducerThunkAction, ProtectedSiteReducerThunkAction } from './types';
 import { siteData, stewardshipActivities, adoptedSites } from './actions';
+import protectedApiClient from '../../../api/protectedApiClient';
 
 export const getSiteData = (siteId: number): SiteReducerThunkAction<void> => {
   return (dispatch, getState, { apiClient }) => {
@@ -21,11 +22,11 @@ export const getSiteData = (siteId: number): SiteReducerThunkAction<void> => {
   };
 };
 
-export const getAdoptedSites = (userId: number): ProtectedSiteReducerThunkAction<void> => {
-  return (dispatch, getState, { protectedApiClient }) => {
+export const getAdoptedSites = (): ProtectedSiteReducerThunkAction<void> => {
+  return (dispatch, getState) => {
     dispatch(adoptedSites.loading());
-
-    return protectedApiClient.getAdoptedSites()
+    return protectedApiClient
+      .getAdoptedSites()
       .then((reponse: AdoptedSites) => {
         dispatch(adoptedSites.loaded(reponse));
       })

--- a/src/containers/treePage/ducks/thunks.ts
+++ b/src/containers/treePage/ducks/thunks.ts
@@ -1,0 +1,36 @@
+import { SiteProps, StewardshipActivities, AdoptedSites, SiteReducerThunkAction, ProtectedSiteReducerThunkAction } from './types';
+import { siteData, stewardshipActivities, adoptedSites } from './actions';
+
+export const getSiteData = (siteId: number): SiteReducerThunkAction<void> => {
+  return (dispatch, getState, { apiClient }) => {
+    dispatch(siteData.loading());
+    dispatch(stewardshipActivities.loading());
+
+    return Promise.all([
+      apiClient.getSite(siteId),
+      apiClient.getStewardshipActivities(siteId),
+    ])
+      .then((response: [SiteProps, StewardshipActivities]) => {
+        dispatch(siteData.loaded(response[0]));
+        dispatch(stewardshipActivities.loaded(response[1]));
+      })
+      .catch((error: any) => {
+        dispatch(siteData.failed(error));
+        dispatch(stewardshipActivities.failed(error));
+      });
+  };
+};
+
+export const getAdoptedSites = (userId: number): ProtectedSiteReducerThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }) => {
+    dispatch(adoptedSites.loading());
+
+    return protectedApiClient.getAdoptedSites()
+      .then((reponse: AdoptedSites) => {
+        dispatch(adoptedSites.loaded(reponse));
+      })
+      .catch((error: any) => {
+        dispatch(adoptedSites.failed(error));
+      });
+  };
+};

--- a/src/containers/treePage/ducks/thunks.ts
+++ b/src/containers/treePage/ducks/thunks.ts
@@ -1,4 +1,4 @@
-import { SiteProps, StewardshipActivities, AdoptedSites, SiteReducerThunkAction, ProtectedSiteReducerThunkAction } from './types';
+import { SiteProps, StewardshipActivities, AdoptedSites, SiteReducerThunkAction, ProtectedSiteReducerThunkAction, ActivityRequest } from './types';
 import { siteData, stewardshipActivities, adoptedSites } from './actions';
 import protectedApiClient from '../../../api/protectedApiClient';
 

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -102,17 +102,20 @@ export interface TreeCare {
 }
 
 export interface StewardshipActivities {
-  activities: Activity[]
+  stewardshipActivities: ActivityLog[]
 }
 
 export interface Activity {
-  id: number;
-  userId: number;
-  date: Date;
   watered: boolean;
   mulched: boolean;
   cleaned: boolean;
   weeded: boolean;
+}
+
+export interface ActivityLog extends Activity {
+  id: number;
+  userId: number;
+  date: Date;
 }
 
 export interface AdoptedSites {
@@ -128,6 +131,11 @@ export interface SiteReducerState {
 
 export interface ProtectedSitesReducerState {
   readonly adoptedSites: AsyncRequest<AdoptedSites, any>
+}
+
+export interface Entry {
+  title: string;
+  value: string;
 }
 
 export type SiteReducerThunkAction<R> = ThunkAction<

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -1,3 +1,10 @@
+import { C4CState } from '../../../store';
+import { ThunkAction } from 'redux-thunk';
+import { SiteActions, ProtectedSiteActions } from './actions';
+import { ApiExtraArgs } from '../../../api/apiClient';
+import { ProtectedApiExtraArgs } from '../../../api/protectedApiClient';
+import { AsyncRequest } from '../../../utils/asyncRequest';
+
 export interface SiteProps {
   siteId: number;
   blockId: number;
@@ -93,3 +100,46 @@ export interface TreeCare {
   date: string;
   message: string;
 }
+
+export interface StewardshipActivities {
+  activities: Activity[]
+}
+
+export interface Activity {
+  id: number;
+  userId: number;
+  date: Date;
+  watered: boolean;
+  mulched: boolean;
+  cleaned: boolean;
+  weeded: boolean;
+}
+
+export interface AdoptedSites {
+  adoptedSites: number[] 
+}
+
+// ---------------------------------Redux----------------------------------------
+
+export interface SiteReducerState {
+  readonly siteData: AsyncRequest<SiteProps, any>;
+  readonly stewarshipActivityData: AsyncRequest<StewardshipActivities, any>;
+}
+
+export interface ProtectedSitesReducerState {
+  readonly adoptedSites: AsyncRequest<AdoptedSites, any>
+}
+
+export type SiteReducerThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ApiExtraArgs,
+  SiteActions
+>;
+
+export type ProtectedSiteReducerThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ProtectedApiExtraArgs,
+  ProtectedSiteActions
+>;

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -102,7 +102,7 @@ export interface TreeCare {
 }
 
 export interface StewardshipActivities {
-  stewardshipActivities: ActivityLog[]
+  stewardshipActivities: ActivityLog[];
 }
 
 export interface Activity {
@@ -122,7 +122,7 @@ export interface ActivityLog extends ActivityRequest {
 }
 
 export interface AdoptedSites {
-  adoptedSites: number[] 
+  adoptedSites: number[];
 }
 
 // ---------------------------------Redux----------------------------------------
@@ -133,7 +133,7 @@ export interface SiteReducerState {
 }
 
 export interface ProtectedSitesReducerState {
-  readonly adoptedSites: AsyncRequest<AdoptedSites, any>
+  readonly adoptedSites: AsyncRequest<AdoptedSites, any>;
 }
 
 export interface Entry {

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -112,10 +112,13 @@ export interface Activity {
   weeded: boolean;
 }
 
-export interface ActivityLog extends Activity {
+export interface ActivityRequest extends Activity {
+  date: string;
+}
+
+export interface ActivityLog extends ActivityRequest {
   id: number;
   userId: number;
-  date: Date;
 }
 
 export interface AdoptedSites {

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import PageLayout from '../../components/pageLayout';
 import ReturnButton from '../../components/returnButton';
 import { Row, Col, Typography, Button, Card, message, Form } from 'antd';
-import { Routes } from '../../App';
+import { RedirectStateProps, Routes } from '../../App';
 import { Helmet } from 'react-helmet';
-import {
-  UserAuthenticationReducerState,
-} from '../../auth/ducks/types';
+import { UserAuthenticationReducerState } from '../../auth/ducks/types';
 import { isLoggedIn } from '../../auth/ducks/selectors';
 import { TreeCare, ActivityRequest } from './ducks/types';
 import PageHeader from '../../components/pageHeader';
@@ -114,6 +112,7 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
   const dispatch = useDispatch();
   const id = Number(useParams<TreeParams>().id);
   const history = useHistory();
+  const location = useLocation<RedirectStateProps>();
 
   const [stewardshipFormInstance] = Form.useForm();
 
@@ -223,22 +222,23 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
                             Unadopt
                           </Button>
                         ) : (
-                          <Button
-                            type="primary"
-                            size="large"
-                            onClick={onClickAdopt}
-                          >
-                            Adopt
-                          </Button>
+                          <>
+                            <Button
+                              type="primary"
+                              size="large"
+                              onClick={onClickAdopt}
+                            >
+                              Adopt
+                            </Button>
+                            <StewardshipContainer>
+                              <Title level={3}>Record Tree Care</Title>
+                              <StewardshipForm
+                                onFinish={onFinishRecordStewardship}
+                                form={stewardshipFormInstance}
+                              />
+                            </StewardshipContainer>
+                          </>
                         )}
-
-                        <StewardshipContainer>
-                          <Title level={3}>Record Tree Care</Title>
-                          <StewardshipForm
-                            onFinish={onFinishRecordStewardship}
-                            form={stewardshipFormInstance}
-                          />
-                        </StewardshipContainer>
                       </>
                     ) : (
                       <>
@@ -246,7 +246,11 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
                         <Button
                           type="primary"
                           size={'large'}
-                          onClick={() => history.push(Routes.LOGIN)}
+                          onClick={() =>
+                            history.push(Routes.LOGIN, {
+                              destination: location.pathname,
+                            })
+                          }
                         >
                           Log In
                         </Button>

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -102,18 +102,6 @@ interface TreeParams {
   id: string;
 }
 
-const onFinishRecordStewardship = (values: {
-  activityDate: moment.Moment;
-  stewardshipActivities: string[];
-}) => {
-  const activities: Activity = {
-    watered: values.stewardshipActivities.includes('Watered'),
-    mulched: values.stewardshipActivities.includes('Mulched'),
-    cleaned: values.stewardshipActivities.includes('Cleaned'),
-    weeded: values.stewardshipActivities.includes('Weeded')
-  }
-};
-
 const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, adoptedSites, tokens }) => {
   const dispatch = useDispatch();
   const id = Number(useParams<TreeParams>().id);
@@ -124,6 +112,19 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, adoptedSites, to
       dispatch(getAdoptedSites());
     }
   }, [dispatch, id, tokens]);
+
+  const onFinishRecordStewardship = (values: {
+    activityDate: moment.Moment;
+    stewardshipActivities: string[];
+  }) => {
+    const activities: Activity = {
+      watered: values.stewardshipActivities.includes('Watered'),
+      mulched: values.stewardshipActivities.includes('Mulched'),
+      cleaned: values.stewardshipActivities.includes('Cleaned'),
+      weeded: values.stewardshipActivities.includes('Weeded'),
+    }
+    
+  };
 
   const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
     return getPrivilegeLevel(state.authenticationState.tokens);

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -214,13 +214,22 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
                     {loggedIn ? (
                       <>
                         {doesUserOwnTree ? (
-                          <Button
-                            type="primary"
-                            size="large"
-                            onClick={onClickUnadopt}
-                          >
-                            Unadopt
-                          </Button>
+                          <>
+                            <Button
+                              type="primary"
+                              size="large"
+                              onClick={onClickUnadopt}
+                            >
+                              Unadopt
+                            </Button>
+                            <StewardshipContainer>
+                              <Title level={3}>Record Tree Care</Title>
+                              <StewardshipForm
+                                onFinish={onFinishRecordStewardship}
+                                form={stewardshipFormInstance}
+                              />
+                            </StewardshipContainer>
+                          </>
                         ) : (
                           <>
                             <Button
@@ -230,13 +239,6 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
                             >
                               Adopt
                             </Button>
-                            <StewardshipContainer>
-                              <Title level={3}>Record Tree Care</Title>
-                              <StewardshipForm
-                                onFinish={onFinishRecordStewardship}
-                                form={stewardshipFormInstance}
-                              />
-                            </StewardshipContainer>
                           </>
                         )}
                       </>

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import PageLayout from '../../components/pageLayout';
 import ReturnButton from '../../components/returnButton';
 import { Row, Col, Typography, Button, Card } from 'antd';
@@ -12,6 +13,11 @@ import { connect } from 'react-redux';
 import { LIGHT_GREY, DARK_GREEN, TEXT_GREY } from '../../utils/colors';
 import { Gap } from '../../components/themedComponents';
 import styled from 'styled-components';
+import { SiteReducerState, ProtectedSitesReducerState } from './ducks/types';
+import { mapStewardshipToTreeCare, isTreeAdopted } from './ducks/selectors';  
+import { asyncRequestIsComplete } from '../../utils/asyncRequest';
+import { C4CState } from '../../store';
+import { siteData } from './ducks/actions';
 
 const { Paragraph, Title } = Typography;
 
@@ -79,6 +85,23 @@ const EntryMessage = styled(Paragraph)`
   color: ${TEXT_GREY};
 `;
 
+interface TreeProps {
+  readonly siteData: SiteReducerState['siteData'];
+  readonly stewardShip: TreeCare[];
+  readonly adoptedSites?: boolean;
+}
+
+const { id } = useParams<{ id: string }>();
+const numId = +id;
+
+const mapStateToProps = (state: C4CState): TreeProps => {
+  return {
+    siteData: state.siteState.siteData,
+    stewardShip: mapStewardshipToTreeCare(state.siteState.stewarshipActivityData),
+    adoptedSites: isTreeAdopted(state.adoptedSitesState.adoptedSites, numId),
+  }
+};
+
 const dummyCare: TreeCare[] = [
   {
     date: 'March 28th',
@@ -136,9 +159,7 @@ const dummyTree: SiteProps = {
   ],
 };
 
-const TreePage: React.FC<SiteProps> = ({ address, entries }) => {
-  const latestEntry: SiteEntry = entries[entries.length - 1];
-
+const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, adoptedSites }) => {
   return (
     <>
       <Helmet>
@@ -149,62 +170,64 @@ const TreePage: React.FC<SiteProps> = ({ address, entries }) => {
         />
       </Helmet>
       <PageLayout>
-        <TreePageContainer>
-          {/*Change to tree map route once that page is finished*/}
-          <ReturnButton to={Routes.HOME}>{`<`} Return to Tree Map</ReturnButton>
-          <TreeMainContainer>
+        {asyncRequestIsComplete(siteData) && (
+          <TreePageContainer>
+            {/*Change to tree map route once that page is finished*/}
+            <ReturnButton to={Routes.HOME}>{`<`} Return to Tree Map</ReturnButton>
+            <TreeMainContainer>
+              <Row>
+                <Col span={17}>
+                  <TreeInfoContainer>
+                    {siteData.result.entries[0].commonName && (
+                      <PageHeader pageTitle={siteData.result.entries[0].commonName} />
+                    )}
+                    <Title level={2}>{siteData.result.address}</Title>
+                    {adoptedSites !== undefined && (
+                      <>
+                        <Button type="primary" size="large">
+                          { adoptedSites ? "Unadopt" : "Adopt" }
+                        </Button>
+                        <StewardshipContainer>
+                          <Title level={3}>Record Tree Care</Title>
+                          <StewardshipForm />
+                        </StewardshipContainer>
+                      </>
+                    )}
+                  </TreeInfoContainer>
+                </Col>
+                <Col span={7}>
+                  <TreeCareContainer>
+                    <TreeCareTitle>Tree Care Activity</TreeCareTitle>
+                    {stewardShip.map((value: TreeCare, key) => {
+                      return (
+                        <CareEntry key={key}>
+                          <EntryDate>{value.date}</EntryDate>
+                          <Gap />
+                          <EntryMessage>{value.message}</EntryMessage>
+                        </CareEntry>
+                      );
+                    })}
+                  </TreeCareContainer>
+                </Col>
+              </Row>
+            </TreeMainContainer>
             <Row>
-              <Col span={17}>
-                <TreeInfoContainer>
-                  {latestEntry.commonName && (
-                    <PageHeader pageTitle={latestEntry.commonName} />
-                  )}
-                  <Title level={2}>{address}</Title>
-                  <Button type="primary" size="large">
-                    Adopt
-                  </Button>
-                  <StewardshipContainer>
-                    <Title level={3}>Record Tree Care</Title>
-                    <StewardshipForm />
-                  </StewardshipContainer>
-                </TreeInfoContainer>
-              </Col>
-              <Col span={7}>
-                <TreeCareContainer>
-                  <TreeCareTitle>Tree Care Activity</TreeCareTitle>
-                  {dummyCare.map((value: TreeCare, key) => {
-                    return (
-                      <CareEntry key={key}>
-                        <EntryDate>{value.date}</EntryDate>
-                        <Gap />
-                        <EntryMessage>{value.message}</EntryMessage>
-                      </CareEntry>
-                    );
-                  })}
-                </TreeCareContainer>
-              </Col>
+              <EntrySpace>
+                {Object.entries(siteData.result.entries[0]).map(([key, value]) => {
+                  return (
+                    <StyledCard key={key}>
+                      <Title level={3}>{SiteEntryNames[key]}</Title>
+                      <EntryMessage>{value.toString()}</EntryMessage>
+                    </StyledCard>
+                  );
+                })}
+              </EntrySpace>
             </Row>
-          </TreeMainContainer>
-          <Row>
-            <EntrySpace>
-              {Object.entries(latestEntry).map(([key, value]) => {
-                return (
-                  <StyledCard key={key}>
-                    <Title level={3}>{SiteEntryNames[key]}</Title>
-                    <EntryMessage>{value.toString()}</EntryMessage>
-                  </StyledCard>
-                );
-              })}
-            </EntrySpace>
-          </Row>
-        </TreePageContainer>
+          </TreePageContainer>
+        )}
       </PageLayout>
     </>
   );
-};
-
-const mapStateToProps = (): SiteProps => {
-  return dummyTree;
 };
 
 export default connect(mapStateToProps)(TreePage);

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,6 +43,14 @@ import { AvailableTeamsReducerState } from './containers/availableTeams/ducks/ty
 import availableTeamsReducer, {
   initialAvailableTeamsState,
 } from './containers/availableTeams/ducks/reducer';
+import { SiteActions, ProtectedSiteActions } from './containers/treePage/ducks/actions';
+import { SiteReducerState, ProtectedSitesReducerState } from './containers/treePage/ducks/types';
+import siteDataReducer, {
+  initialSiteState
+} from './containers/treePage/ducks/reducer';
+import protectedSitesDataReducer, {
+  initialProtectedSiteState
+} from './containers/treePage/ducks/protectedReducer';
 import throttle from 'lodash/throttle';
 import AppAxiosInstance from './auth/axios';
 import { asyncRequestIsComplete } from './utils/asyncRequest';
@@ -54,6 +62,8 @@ export interface C4CState {
   mapGeoDataState: MapGeoDataReducerState;
   teamState: TeamReducerState;
   availableTeamsState: AvailableTeamsReducerState;
+  siteState: SiteReducerState;
+  adoptedSitesState: ProtectedSitesReducerState;
 }
 
 export interface Action<T, P> {
@@ -67,7 +77,9 @@ export type C4CAction =
   | VolunteerLeaderboardItemAction
   | TeamLeaderboardItemAction
   | TeamResponseAction
-  | AvailableTeamsAction;
+  | AvailableTeamsAction
+  | SiteActions
+  | ProtectedSiteActions;
 
 export type ThunkExtraArgs = UserAuthenticationExtraArgs &
   ProtectedApiExtraArgs &
@@ -80,6 +92,8 @@ const reducers = combineReducers<C4CState, C4CAction>({
   mapGeoDataState: mapGeoDataReducer,
   teamState: teamReducer,
   availableTeamsState: availableTeamsReducer,
+  siteState: siteDataReducer,
+  adoptedSitesState: protectedSitesDataReducer,
 });
 
 export const initialStoreState: C4CState = {
@@ -89,6 +103,8 @@ export const initialStoreState: C4CState = {
   mapGeoDataState: initialMapGeoDataState,
   teamState: initialTeamState,
   availableTeamsState: initialAvailableTeamsState,
+  siteState: initialSiteState,
+  adoptedSitesState: initialProtectedSiteState
 };
 
 export const LOCALSTORAGE_STATE_KEY: string = 'state';

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,13 +43,19 @@ import { AvailableTeamsReducerState } from './containers/availableTeams/ducks/ty
 import availableTeamsReducer, {
   initialAvailableTeamsState,
 } from './containers/availableTeams/ducks/reducer';
-import { SiteActions, ProtectedSiteActions } from './containers/treePage/ducks/actions';
-import { SiteReducerState, ProtectedSitesReducerState } from './containers/treePage/ducks/types';
+import {
+  SiteActions,
+  ProtectedSiteActions,
+} from './containers/treePage/ducks/actions';
+import {
+  SiteReducerState,
+  ProtectedSitesReducerState,
+} from './containers/treePage/ducks/types';
 import siteDataReducer, {
-  initialSiteState
+  initialSiteState,
 } from './containers/treePage/ducks/reducer';
 import protectedSitesDataReducer, {
-  initialProtectedSiteState
+  initialProtectedSiteState,
 } from './containers/treePage/ducks/protectedReducer';
 import throttle from 'lodash/throttle';
 import AppAxiosInstance from './auth/axios';
@@ -104,7 +110,7 @@ export const initialStoreState: C4CState = {
   teamState: initialTeamState,
   availableTeamsState: initialAvailableTeamsState,
   siteState: initialSiteState,
-  adoptedSitesState: initialProtectedSiteState
+  adoptedSitesState: initialProtectedSiteState,
 };
 
 export const LOCALSTORAGE_STATE_KEY: string = 'state';


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1185039378)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

This PR allows users to view the stats about a particular tree as well as the stewardship activities that have been performed. This also allows the user to adopt, unadopt, and perform stewardship activities on those trees

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Created the api routes, reducers, thunks, and selectors that retrieve data from the backend, put it in redux, and display that data on the frontend. I also made changes to the treepage that allowed it to work with these changes

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![logged out tree](https://user-images.githubusercontent.com/19194912/117522778-33d36280-af83-11eb-8c6e-5b4b43c80779.PNG)

![real tree](https://user-images.githubusercontent.com/19194912/117522789-3e8df780-af83-11eb-8232-49ca4a17d318.PNG)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

Double checked the results of these routes in postman. Made sure those calls gave the same results from the UI. Currently the unadopt does not work in the backend so once that is fixed there may be some fixes needed. The get routes have results that are displayed on the page so those are fairly self evident. Wrote tests for the routes. Will make another ticket to complete the thunks, selector, and reducer tests. This PR is just somewhat time sensitive.
