### PR TITLE
made subtitlecolor prop lower case to remove react warning

### DIFF
--- a/src/components/pageHeader/index.tsx
+++ b/src/components/pageHeader/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const { Paragraph } = Typography;
 
 interface StyledSubtitleProps {
-  readonly subtitleColor?: string;
+  readonly subtitlecolor?: string;
 }
 
 const StyledTitle = styled(Paragraph)`
@@ -28,7 +28,7 @@ const StyledSubtitle = styled(Paragraph)`
   line-height: 32px;
   margin-top: -40px;
   color: ${(props: StyledSubtitleProps) =>
-    props.subtitleColor ? props.subtitleColor : { DARK_GREY }};
+    props.subtitlecolor ? props.subtitlecolor : { DARK_GREY }};
 `;
 
 interface PageHeaderProps extends StyledSubtitleProps {
@@ -41,7 +41,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
   pageTitle,
   isMobile,
   pageSubtitle,
-  subtitleColor,
+  subtitlecolor,
 }) => {
   if (isMobile) {
     return (
@@ -53,7 +53,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
     return (
       <>
         <StyledTitle>{pageTitle}</StyledTitle>
-        <StyledSubtitle subtitleColor={subtitleColor}>
+        <StyledSubtitle subtitlecolor={subtitlecolor}>
           {pageSubtitle}
         </StyledSubtitle>
       </>

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -112,7 +112,7 @@ const Home: React.FC = () => {
                     <PageHeader
                       pageTitle={greeting}
                       pageSubtitle={HOME_HEADER}
-                      subtitleColor={DARK_GREY}
+                      subtitlecolor={DARK_GREY}
                     />
                     <StyledSubtitle>Quick Links</StyledSubtitle>
                     <List
@@ -137,7 +137,7 @@ const Home: React.FC = () => {
                     <PageHeader
                       pageTitle={greeting}
                       pageSubtitle={HOME_HEADER}
-                      subtitleColor={DARK_GREY}
+                      subtitlecolor={DARK_GREY}
                     />
                     <StyledSubtitle>Quick Links</StyledSubtitle>
                     <List


### PR DESCRIPTION
## Why

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

There was a console warning about using camel case in dom props. This change removes that warning

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

I simply changed the subtitle prop from camelCase to lowercase

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![console](https://user-images.githubusercontent.com/19194912/119267605-61442100-bbbd-11eb-90d6-948d19fc25a8.PNG)

That particular warning is gone

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

The pageheaders still display their subtitles with the correct colors
