### PR TITLE
added tree colors to map

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -238,8 +238,7 @@ const createTeam = (request: CreateTeamRequest): Promise<void> => {
 };
 
 const getTeams = (): Promise<TeamResponse[]> => {
-  return AppAxiosInstance.get(baseTeamRoute)
-    .then((res) => res.data)
+  return AppAxiosInstance.get(baseTeamRoute).then((res) => res.data);
 };
 
 const getTeam = (teamId: number): Promise<TeamResponse> => {

--- a/src/components/mapPageComponents/ducks/types.ts
+++ b/src/components/mapPageComponents/ducks/types.ts
@@ -70,6 +70,8 @@ interface SiteFeaturePropertiesResponse {
   address: string;
   lat: number;
   lng: number;
+  plantingDate?: number;
+  adopterId?: string;
 }
 
 // ---------------------------------Shared Types----------------------------------------

--- a/src/components/mapPageComponents/ducks/types.ts
+++ b/src/components/mapPageComponents/ducks/types.ts
@@ -63,11 +63,11 @@ interface SiteFeatureResponse {
 interface SiteFeaturePropertiesResponse {
   id: number;
   treePresent: boolean;
-  diameter: number;
-  species: string;
+  diameter?: number;
+  species?: string;
   updatedAt: string;
   updatedBy: string;
-  address: string;
+  address?: string;
   lat: number;
   lng: number;
   plantingDate?: number;

--- a/src/components/mapPageComponents/mapView/index.tsx
+++ b/src/components/mapPageComponents/mapView/index.tsx
@@ -374,8 +374,8 @@ const MapView: React.FC<MapViewProps> = ({
               visible = v && true;
             }
 
-            // TODO: update this to if the tree was planted within the past three years
-            // If the tree has not been updated within the past three years, use youngTreeIcon
+            // If the tree was planted within the past three years, use youngTreeIcon
+            // If the tree is adopted, use the adoptedTreeIcon
             const plantedDate = feature.getProperty('plantingDate');
             const adopted = !!feature.getProperty('adopterId');
             if (adopted) {

--- a/src/components/mapPageComponents/mapView/index.tsx
+++ b/src/components/mapPageComponents/mapView/index.tsx
@@ -16,6 +16,7 @@ import { shortHand } from '../../../utils/stringFormat';
 import { SHORT_HAND_NAMES } from '../../../assets/content';
 import treeIcon from '../../../assets/images/treeIcon.png';
 import youngTreeIcon from '../../../assets/images/youngTreeIcon.png';
+import adoptedTreeIcon from '../../../assets/images/adoptedTreeIcon.png';
 import { isMobile } from '../../../utils/isCheck';
 
 const StyledSearch = styled(Input.Search)`
@@ -375,9 +376,14 @@ const MapView: React.FC<MapViewProps> = ({
 
             // TODO: update this to if the tree was planted within the past three years
             // If the tree has not been updated within the past three years, use youngTreeIcon
-            const updatedDate = feature.getProperty('updated_at');
-            if (updatedDate < breakpointDate) {
+            const plantedDate = feature.getProperty('plantingDate');
+            const adopted = !!feature.getProperty('adopterId');
+            if (adopted) {
+              icon = adoptedTreeIcon;
+            } else if (!!plantedDate && plantedDate > breakpointDate) {
               icon = youngTreeIcon;
+            } else {
+              icon = treeIcon;
             }
 
             return {

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -12,7 +12,7 @@ export interface SiteProps {
   lng: number;
   city: string;
   zip: string;
-  address: string;
+  address?: string;
   entries: SiteEntry[];
 }
 

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -210,7 +210,9 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardShip, tokens }) => {
                         pageTitle={siteData.result.entries[0].commonName}
                       />
                     )}
-                    <Title level={2}>{siteData.result.address}</Title>
+                    {siteData.result.address && (
+                      <Title level={2}>{siteData.result.address}</Title>
+                    )}
                     {loggedIn ? (
                       <>
                         {doesUserOwnTree ? (


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1263481139)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

This PR gives different colors to trees based on their attributes. Young trees are blue and adopted trees are red

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

I added the planting date and adopter id to the site feature type and added a condition to the styling of the sites on the map that selects the correct color

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![tree-colors](https://user-images.githubusercontent.com/19194912/119428703-65fef700-bcdb-11eb-99eb-7444ae88c708.PNG)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

I used postman to make sure the planting date and adopter id values were coming back as expected. The changes are cosmetic so I was able to see the change in colors on the map
