### PR TITLE
Update Tree Page Styling Across Window Types

### DIFF
--- a/src/components/forms/ducks/types.ts
+++ b/src/components/forms/ducks/types.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { PrivilegeLevel, SignupRequest } from '../../../auth/ducks/types';
 
 export interface AuthRequest {
@@ -29,4 +30,9 @@ export interface ChangePrivilegeRequest {
   readonly targetUserEmail: string;
   readonly newLevel: PrivilegeLevel;
   readonly password: string;
+}
+
+export interface RecordStewardshipRequest {
+  readonly activityDate: moment.Moment;
+  readonly stewardshipActivities: string[];
 }

--- a/src/components/forms/stewardshipForm/index.tsx
+++ b/src/components/forms/stewardshipForm/index.tsx
@@ -9,7 +9,7 @@ import {
   FormInstance,
 } from 'antd';
 import styled from 'styled-components';
-import { activitiesDateRules, activitiesRules } from '../../utils/formRules';
+import { activitiesDateRules, activitiesRules } from '../../../utils/formRules';
 
 const { Paragraph } = Typography;
 
@@ -18,7 +18,7 @@ const ItemLabel = styled(Paragraph)`
 `;
 
 const TreeDatePicker = styled(DatePicker)`
-  width: 50%;
+  width: 45%;
 `;
 
 interface StewardshipFormProps {
@@ -40,6 +40,13 @@ const StewardshipForm: React.FC<StewardshipFormProps> = ({
     'Cleared Waste & Litter',
   ];
 
+  const disabledDate = (current: moment.Moment): boolean => {
+    // Can not select future days or days more than two weeks ago
+    return (
+      current > moment().endOf('day') || current < moment().subtract(2, 'weeks')
+    );
+  };
+
   return (
     <>
       <Form
@@ -50,7 +57,7 @@ const StewardshipForm: React.FC<StewardshipFormProps> = ({
       >
         <ItemLabel>Activity Date</ItemLabel>
         <Form.Item name="activityDate" rules={activitiesDateRules}>
-          <TreeDatePicker format={'MM/DD/YYYY'} />
+          <TreeDatePicker format={'MM/DD/YYYY'} disabledDate={disabledDate} />
         </Form.Item>
         <ItemLabel>Stewardship Activites</ItemLabel>
         <Form.Item name="stewardshipActivities" rules={activitiesRules}>

--- a/src/components/mapPageComponents/mapView/index.tsx
+++ b/src/components/mapPageComponents/mapView/index.tsx
@@ -90,7 +90,7 @@ const MapView: React.FC<MapViewProps> = ({
         break;
       case ReservationModalType.RESERVED:
         // set block status to open
-        protectedApiClient.releaseReservation(activeBlockId);
+        await protectedApiClient.releaseReservation(activeBlockId);
         break;
       case ReservationModalType.TAKEN:
         // block clicked not owned/open so do nothing
@@ -375,7 +375,7 @@ const MapView: React.FC<MapViewProps> = ({
         function setSitesStyle(v: boolean) {
           sitesLayer.setStyle((feature) => {
             let visible = false;
-            let icon = treeIcon;
+            let icon;
 
             // Only shows sites if there is a tree there
             if (feature.getProperty('tree_present')) {

--- a/src/components/pageHeader/index.tsx
+++ b/src/components/pageHeader/index.tsx
@@ -16,7 +16,7 @@ const StyledTitle = styled(Paragraph)`
 `;
 
 const MobileStyledTitle = styled(Paragraph)`
-  font-size: 28px;
+  font-size: 30px;
   line-height: 48px;
   color: ${DARK_GREEN};
   font-weight: bold;
@@ -27,6 +27,15 @@ const StyledSubtitle = styled(Paragraph)`
   font-size: 24px;
   line-height: 32px;
   margin-top: -40px;
+  color: ${(props: StyledSubtitleProps) =>
+    props.subtitlecolor ? props.subtitlecolor : { DARK_GREY }};
+`;
+
+const MobileStyledSubtitle = styled(Paragraph)`
+  font-weight: normal;
+  font-size: 14px;
+  line-height: 14px;
+  margin-top: -20px;
   color: ${(props: StyledSubtitleProps) =>
     props.subtitlecolor ? props.subtitlecolor : { DARK_GREY }};
 `;
@@ -47,6 +56,9 @@ const PageHeader: React.FC<PageHeaderProps> = ({
     return (
       <>
         <MobileStyledTitle>{pageTitle}</MobileStyledTitle>
+        <MobileStyledSubtitle subtitlecolor={subtitlecolor}>
+          {pageSubtitle}
+        </MobileStyledSubtitle>
       </>
     );
   } else {

--- a/src/components/treeActivity/index.tsx
+++ b/src/components/treeActivity/index.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Row, Col, Typography, List } from 'antd';
+import { TreeCare } from '../../containers/treePage/ducks/types';
+import { TitleProps } from 'antd/lib/typography/Title';
+import { DARK_GREEN, TEXT_GREY } from '../../utils/colors';
+import styled from 'styled-components';
+
+const { Paragraph } = Typography;
+
+const TreeCareTitle = styled(Paragraph)`
+  margin: 0px 5px;
+  font-size: 26px;
+  font-weight: bold;
+  line-height: 26px;
+  color: ${DARK_GREEN};
+`;
+
+const CareEntry = styled.div`
+  margin: 15px;
+`;
+
+const EntryDate = styled(Paragraph)<TitleProps>`
+  display: inline;
+  text-align: center;
+  line-height: 0px;
+  font-size: 18px;
+  font-weight: bold;
+  color: ${DARK_GREEN};
+`;
+
+const EntryMessage = styled(Paragraph)`
+  display: inline;
+  text-align: center;
+  line-height: 0px;
+  color: ${TEXT_GREY};
+`;
+
+interface TreeActivityProps {
+  readonly stewardship: TreeCare[];
+}
+
+const TreeActivity: React.FC<TreeActivityProps> = ({ stewardship }) => {
+  return (
+    <>
+      <TreeCareTitle>Tree Care Activity</TreeCareTitle>
+      <List
+        dataSource={stewardship}
+        itemLayout="vertical"
+        locale={{
+          emptyText: 'No Stewardship Activities Recorded for this Tree',
+        }}
+        renderItem={(value, key) => (
+          <CareEntry key={key}>
+            <Row>
+              <Col span={5}>
+                <EntryDate>{value.date}</EntryDate>
+              </Col>
+              <Col span={1} />
+              <Col span={18}>
+                <EntryMessage>{value.message}</EntryMessage>
+              </Col>
+            </Row>
+          </CareEntry>
+        )}
+      />
+    </>
+  );
+};
+
+export default TreeActivity;

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Typography, Button, FormInstance } from 'antd';
+import { RedirectStateProps, Routes } from '../../App';
+import PageHeader from '../../components/pageHeader';
+import StewardshipForm from '../forms/stewardshipForm';
+import styled from 'styled-components';
+import { SiteProps } from '../../containers/treePage/ducks/types';
+import { RecordStewardshipRequest } from '../forms/ducks/types';
+import { MID_GREEN } from '../../utils/colors';
+
+const { Title } = Typography;
+
+const TreeInfoContainer = styled.div`
+  text-transform: capitalize;
+`;
+
+const StewardshipContainer = styled.div`
+  margin-top: 40px;
+`;
+
+const ToggleTextButton = styled(Button)`
+  padding: 0px;
+`;
+
+interface TreeProps {
+  readonly siteData: SiteProps;
+  readonly loggedIn: boolean;
+  readonly userOwnsTree: boolean;
+  readonly mobile?: boolean;
+  readonly onClickAdopt: () => void;
+  readonly onClickUnadopt: () => void;
+  readonly onFinishRecordStewardship: (
+    values: RecordStewardshipRequest,
+  ) => void;
+  readonly stewardshipFormInstance: FormInstance;
+}
+
+const TreeInfo: React.FC<TreeProps> = ({
+  siteData,
+  loggedIn,
+  userOwnsTree,
+  mobile,
+  onClickAdopt,
+  onClickUnadopt,
+  onFinishRecordStewardship,
+  stewardshipFormInstance,
+}) => {
+  const history = useHistory();
+  const location = useLocation<RedirectStateProps>();
+
+  const getSiteLocation = (): string => {
+    const baseLocation = `${siteData.city} ${siteData.zip}`;
+
+    if (siteData.address) {
+      return `${siteData.address}, ${baseLocation}`;
+    } else {
+      return baseLocation;
+    }
+  };
+
+  return (
+    <TreeInfoContainer>
+      {siteData.entries[0].commonName && (
+        <PageHeader
+          pageTitle={siteData.entries[0].commonName}
+          isMobile={mobile}
+          pageSubtitle={getSiteLocation()}
+          subtitlecolor={MID_GREEN}
+        />
+      )}
+
+      {(() => {
+        switch (loggedIn) {
+          case true:
+            return (
+              <>
+                {userOwnsTree ? (
+                  <>
+                    <Button
+                      type="primary"
+                      size={mobile ? 'middle' : 'large'}
+                      onClick={onClickUnadopt}
+                    >
+                      Unadopt
+                    </Button>
+                    <StewardshipContainer>
+                      <Title level={3}>Record Tree Care</Title>
+                      <StewardshipForm
+                        onFinish={onFinishRecordStewardship}
+                        form={stewardshipFormInstance}
+                      />
+                    </StewardshipContainer>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      type="primary"
+                      size={mobile ? 'middle' : 'large'}
+                      onClick={onClickAdopt}
+                    >
+                      Adopt
+                    </Button>
+                  </>
+                )}
+              </>
+            );
+          case false:
+            return (
+              <ToggleTextButton
+                type="link"
+                size="large"
+                onClick={() =>
+                  history.push(Routes.LOGIN, {
+                    destination: location.pathname,
+                  })
+                }
+              >
+                Log in to adopt this tree!
+              </ToggleTextButton>
+            );
+        }
+      })()}
+    </TreeInfoContainer>
+  );
+};
+
+export default TreeInfo;

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -50,7 +50,11 @@ const TreeInfo: React.FC<TreeProps> = ({
   const location = useLocation<RedirectStateProps>();
 
   const getSiteLocation = (): string => {
-    const baseLocation = `${siteData.city} ${siteData.zip}`;
+    // TODO change to siteData.city and remove check for zip after data is cleaned
+    let baseLocation = `Boston`;
+    if (siteData.zip) {
+      baseLocation += ` 0${siteData.zip}`;
+    }
 
     if (siteData.address) {
       return `${siteData.address}, ${baseLocation}`;

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -10,6 +10,7 @@ import {
   Entry,
   SiteEntryNames,
 } from './types';
+import { formatDateSuffix } from '../../../utils/stringFormat';
 
 export const mapStewardshipToTreeCare = (
   items: AsyncRequest<StewardshipActivities, any>,
@@ -17,18 +18,17 @@ export const mapStewardshipToTreeCare = (
   if (asyncRequestIsComplete(items)) {
     return items.result.stewardshipActivities.map((item) => {
       const month = new Date(item.date).toLocaleString('default', {
-        month: 'long',
+        month: 'short',
       });
       const day = new Date(item.date).getDate();
 
       const activityStrings = [];
-      // These cause linting errors for some reason
       if (item.cleaned) activityStrings.push('cleared of waste');
       if (item.mulched) activityStrings.push('mulched');
       if (item.watered) activityStrings.push('watered');
       if (item.weeded) activityStrings.push('weeded');
       return {
-        date: `${month} ${day}th`,
+        date: `${month} ${formatDateSuffix(day)}`,
         message: `Was ${activityStrings.join(' and ')}.`,
       };
     });
@@ -42,7 +42,7 @@ export const getLatestEntry = (
   if (asyncRequestIsComplete(items)) {
     return Object.entries(items.result.entries[0]).reduce<Entry[]>(
       (soFar, [key, value]) => {
-        if (SiteEntryNames[key] && value !== null) {
+        if (SiteEntryNames[key] && (value || value === false)) {
           soFar.push({
             title: SiteEntryNames[key],
             value: value.toString(),

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -33,6 +33,7 @@ import useWindowDimensions, {
 import ReturnButton from '../../components/returnButton';
 import TreeInfo from '../../components/treeInfo';
 import TreeActivity from '../../components/treeActivity';
+import { getDateString } from '../../utils/stringFormat';
 
 const { Paragraph, Title } = Typography;
 
@@ -113,7 +114,7 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
 
   const onFinishRecordStewardship = (values: RecordStewardshipRequest) => {
     const activities: ActivityRequest = {
-      date: values.activityDate.add(1, 'day').format('L'),
+      date: values.activityDate.format('L'),
       watered: values.stewardshipActivities.includes('Watered'),
       mulched: values.stewardshipActivities.includes('Mulched'),
       cleaned: values.stewardshipActivities.includes('Cleared Waste & Litter'),

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -33,7 +33,6 @@ import useWindowDimensions, {
 import ReturnButton from '../../components/returnButton';
 import TreeInfo from '../../components/treeInfo';
 import TreeActivity from '../../components/treeActivity';
-import { getDateString } from '../../utils/stringFormat';
 
 const { Paragraph, Title } = Typography;
 

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -113,7 +113,7 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
 
   const onFinishRecordStewardship = (values: RecordStewardshipRequest) => {
     const activities: ActivityRequest = {
-      date: values.activityDate.format('L'),
+      date: values.activityDate.add(1, 'day').format('L'),
       watered: values.stewardshipActivities.includes('Watered'),
       mulched: values.stewardshipActivities.includes('Mulched'),
       cleaned: values.stewardshipActivities.includes('Cleared Waste & Litter'),

--- a/src/utils/stringFormat.tsx
+++ b/src/utils/stringFormat.tsx
@@ -15,6 +15,24 @@ export function getDateString(date: Date): string {
 }
 
 /**
+ * Returns the numeric date formatted with the appropriate suffix.
+ * @param date the numeric day to format
+ */
+export function formatDateSuffix(date: number): string {
+  const lastNumber: number = date % 10;
+  switch (lastNumber) {
+    case 1:
+      return date + 'st';
+    case 2:
+      return date + 'nd';
+    case 3:
+      return date + 'rd';
+    default:
+      return date + 'th';
+  }
+}
+
+/**
  * Returns the shorthand name of the neighborhoods
  * @param name the name to shorten
  * @param shortHandNames the dictionary containing the mappings

--- a/src/utils/stringFormat.tsx
+++ b/src/utils/stringFormat.tsx
@@ -19,6 +19,11 @@ export function getDateString(date: Date): string {
  * @param date the numeric day to format
  */
 export function formatDateSuffix(date: number): string {
+  const tensNum: number = date % 100;
+  if (tensNum > 9 && tensNum < 20) {
+    return date + 'th';
+  }
+
   const lastNumber: number = date % 10;
   switch (lastNumber) {
     case 1:

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -1,4 +1,4 @@
-import { getMoneyString } from '../stringFormat';
+import { formatDateSuffix, getMoneyString } from '../stringFormat';
 import { getDateString } from '../stringFormat';
 import { shortHand } from '../stringFormat';
 import { SHORT_HAND_NAMES } from '../../assets/content';
@@ -11,6 +11,19 @@ test('getMoneyString tests', () => {
 test('getDateString tests', () => {
   expect(getDateString(new Date(2020, 5, 10))).toBe('6/10/2020');
   expect(getDateString(new Date(2025, 11, 21))).toBe('12/21/2025');
+});
+
+test('formatDateSuffix tests', () => {
+  expect(formatDateSuffix(1)).toBe('1st');
+  expect(formatDateSuffix(2)).toBe('2nd');
+  expect(formatDateSuffix(3)).toBe('3rd');
+  expect(formatDateSuffix(4)).toBe('4th');
+  expect(formatDateSuffix(7)).toBe('7th');
+  expect(formatDateSuffix(10)).toBe('10th');
+  expect(formatDateSuffix(31)).toBe('31st');
+  expect(formatDateSuffix(42)).toBe('42nd');
+  expect(formatDateSuffix(109)).toBe('109th');
+  expect(formatDateSuffix(22893074921)).toBe('22893074921st');
 });
 
 test('shortHand tests', () => {

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -19,7 +19,12 @@ test('formatDateSuffix tests', () => {
   expect(formatDateSuffix(3)).toBe('3rd');
   expect(formatDateSuffix(4)).toBe('4th');
   expect(formatDateSuffix(7)).toBe('7th');
-  expect(formatDateSuffix(10)).toBe('10th');
+  expect(formatDateSuffix(11)).toBe('11th');
+  expect(formatDateSuffix(12)).toBe('12th');
+  expect(formatDateSuffix(15)).toBe('15th');
+  expect(formatDateSuffix(19)).toBe('19th');
+  expect(formatDateSuffix(20)).toBe('20th');
+  expect(formatDateSuffix(21)).toBe('21st');
   expect(formatDateSuffix(31)).toBe('31st');
   expect(formatDateSuffix(42)).toBe('42nd');
   expect(formatDateSuffix(109)).toBe('109th');


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1266458984)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Makes the page user-friendly on mobile and improves styling across devices.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Styling Changes
- Generally tried to fill the page more since we don't have a tree photo, allow for scrolling when there's overflow
- Changed format of dates for stewardship records:
  - month is in shorthand to fit the container better
  - suffix after day (`st`/`nd`/`rd`/`th` depends on the day)
- Address includes city and zip code (even if street address is not available, these will be displayed, every site has this information)
- Capitalized tree names
- Followed the standard format for changing styling based on window dimensions.
Functionality
- Users can only input activities done that day or two weeks prior (not in the future or too far in the past) to make sure user input is reasonable and timely
- Some tree data was still being shown despite not having a value, fixed this

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Desktop
<img width="1680" alt="Desktop" src="https://user-images.githubusercontent.com/22990100/120764038-cfee7c00-c4e5-11eb-8aed-d6757efc4989.png">
_Blocked Dates_
<img width="1680" alt="DesktopDatePickerRestrictions" src="https://user-images.githubusercontent.com/22990100/120764047-d1b83f80-c4e5-11eb-9a80-ef47ae755096.png">
_Login Link (replaced button)_
<img width="1680" alt="DesktopNotLoggedInNoData" src="https://user-images.githubusercontent.com/22990100/120764054-d2e96c80-c4e5-11eb-9c56-35f9628e158a.png">
Narrow Desktop (iPadPro Horizontal)
<img width="1134" alt="NarrowDesktop" src="https://user-images.githubusercontent.com/22990100/120764066-d4b33000-c4e5-11eb-9e93-fbcc8d223e4d.png">
Tablet (iPadPro Vertical)
<img width="512" alt="Tablet" src="https://user-images.githubusercontent.com/22990100/120764070-d54bc680-c4e5-11eb-9acc-e03d7a445ba4.png">
Mobile (iPhoneX)
<img width="375" alt="Mobile" src="https://user-images.githubusercontent.com/22990100/120764059-d3820300-c4e5-11eb-9ef2-8aff8aa5664e.png"> <img width="375" alt="MobileScroll" src="https://user-images.githubusercontent.com/22990100/120764061-d41a9980-c4e5-11eb-8243-faa1011fdeaf.png">

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Made sure everything looked reasonable across a variety of device types and checked that routes still worked.
