### PR TITLE
Accessible Routes and Disable Adopt Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,10 +17,6 @@ import { C4CState } from './store';
 import styled from 'styled-components';
 import Landing from './containers/landing';
 import AdminDashboard from './containers/adminDashboard';
-import VolunteerLeaderboard from './containers/volunteerLeaderboard';
-import TeamLeaderboard from './containers/teamLeaderboard';
-import TeamPage from './containers/teamPage';
-import AvailableTeams from './containers/availableTeams';
 import TreePage from './containers/treePage';
 import MyTrees from './containers/myTrees';
 import { Layout } from 'antd';
@@ -30,7 +26,6 @@ import Login from './containers/login';
 import Settings from './containers/settings';
 import NotFound from './containers/notFound';
 import NavBar from './components/navBar';
-import Reservations from './containers/reservations';
 import ForgotPassword from './containers/forgotPassword';
 import ForgotPasswordReset from './containers/forgotPasswordReset';
 import AuthRedirect from './components/authRedirect';
@@ -44,9 +39,9 @@ const AppLayout = styled(Layout)`
 type AppProps = UserAuthenticationReducerState;
 
 export enum ParameterizedRouteBases {
-  TEAM = '/team/',
+  // TEAM = '/team/',
   TREE = '/tree/',
-  FORGOT_PASSWORD_RESET = '/forgot-password-reset/',
+  // FORGOT_PASSWORD_RESET = '/forgot-password-reset/',
 }
 
 export enum Routes {
@@ -55,12 +50,12 @@ export enum Routes {
   SIGNUP = '/signup',
   HOME = '/home',
   SETTINGS = '/settings',
-  VOLUNTEER = '/volunteer',
-  TEAM = '/team/:id',
+  // VOLUNTEER = '/volunteer',
+  // TEAM = '/team/:id',
   TREE = '/tree/:id',
   MY_TREES = '/my-trees',
-  TEAM_LEADERBOARD = '/team-leaderboard',
-  RESERVATIONS = '/reservations',
+  // TEAM_LEADERBOARD = '/team-leaderboard',
+  // RESERVATIONS = '/reservations',
   AVAILABLE_TEAMS = '/available',
   ADMIN = '/admin',
   FORGOT_PASSWORD_REQUEST = '/forgot-password',
@@ -101,12 +96,14 @@ const App: React.FC = () => {
                       <Route path={Routes.TREE} exact component={TreePage} />
                       <AuthRedirect from={Routes.HOME} />
                       <AuthRedirect from={Routes.SETTINGS} />
+                      <AuthRedirect from={Routes.MY_TREES} />
+                      {/*
                       <AuthRedirect from={Routes.VOLUNTEER} />
                       <AuthRedirect from={Routes.TEAM} />
-                      <AuthRedirect from={Routes.MY_TREES} />
                       <AuthRedirect from={Routes.TEAM_LEADERBOARD} />
                       <AuthRedirect from={Routes.AVAILABLE_TEAMS} />
                       <AuthRedirect from={Routes.RESERVATIONS} />
+                      */}
                       <AuthRedirect from={Routes.ADMIN} />
                       <Route
                         path={Routes.FORGOT_PASSWORD_REQUEST}
@@ -132,12 +129,15 @@ const App: React.FC = () => {
                       <Route path={Routes.LANDING} exact component={Landing} />
                       <Route path={Routes.LOGIN} exact component={Login} />
                       <Route path={Routes.SIGNUP} exact component={Signup} />
+                      <Route path={Routes.TREE} exact component={TreePage} />
                       <Route path={Routes.HOME} exact component={Home} />
                       <Route
                         path={Routes.SETTINGS}
                         exact
                         component={Settings}
                       />
+                      <Route path={Routes.MY_TREES} exact component={MyTrees} />
+                      {/*
                       <Route
                         path={Routes.VOLUNTEER}
                         exact
@@ -148,20 +148,19 @@ const App: React.FC = () => {
                         exact
                         component={TeamLeaderboard}
                       />
-                      <Route path={Routes.MY_TREES} exact component={MyTrees} />
                       <Route
                         path={Routes.AVAILABLE_TEAMS}
                         exact
                         component={AvailableTeams}
                       />
+                      <Route path={Routes.TEAM} exact component={TeamPage} />
                       <Route
                         path={Routes.RESERVATIONS}
                         exact
                         component={Reservations}
                       />
+                      */}
                       <Redirect from={Routes.ADMIN} to={Routes.HOME} />
-                      <Route path={Routes.TEAM} exact component={TeamPage} />
-                      <Route path={Routes.TREE} exact component={TreePage} />
                       <Route
                         path={Routes.NOT_FOUND}
                         exact
@@ -177,12 +176,15 @@ const App: React.FC = () => {
                       <Route path={Routes.LANDING} exact component={Landing} />
                       <Route path={Routes.LOGIN} exact component={Login} />
                       <Route path={Routes.SIGNUP} exact component={Signup} />
+                      <Route path={Routes.TREE} exact component={TreePage} />
                       <Route path={Routes.HOME} exact component={Home} />
                       <Route
                         path={Routes.SETTINGS}
                         exact
                         component={Settings}
                       />
+                      <Route path={Routes.MY_TREES} exact component={MyTrees} />
+                      {/*
                       <Route
                         path={Routes.VOLUNTEER}
                         exact
@@ -193,24 +195,23 @@ const App: React.FC = () => {
                         exact
                         component={TeamLeaderboard}
                       />
-                      <Route path={Routes.MY_TREES} exact component={MyTrees} />
                       <Route
                         path={Routes.AVAILABLE_TEAMS}
                         exact
                         component={AvailableTeams}
                       />
+                      <Route path={Routes.TEAM} exact component={TeamPage} />
                       <Route
                         path={Routes.RESERVATIONS}
                         exact
                         component={Reservations}
                       />
+                      */}
                       <Route
                         path={Routes.ADMIN}
                         exact
                         component={AdminDashboard}
                       />
-                      <Route path={Routes.TEAM} exact component={TeamPage} />
-                      <Route path={Routes.TREE} exact component={TreePage} />
                       <Route
                         path={Routes.NOT_FOUND}
                         exact

--- a/src/components/mapPageComponents/mapView/index.tsx
+++ b/src/components/mapPageComponents/mapView/index.tsx
@@ -9,8 +9,6 @@ import {
   SiteGeoData,
   MapViews,
 } from '../ducks/types';
-import ReservationModal, { ReservationModalType } from '../../reservationModal';
-import protectedApiClient from '../../../api/protectedApiClient';
 import TreePopup, {
   BasicTreeInfo,
   NO_SITE_SELECTED,
@@ -71,6 +69,7 @@ const MapView: React.FC<MapViewProps> = ({
   sites,
   view,
 }) => {
+  /*
   // visibility of reservation modal
   const [showModal, setShowModal] = useState<boolean>(false);
   // block status for modal
@@ -79,6 +78,7 @@ const MapView: React.FC<MapViewProps> = ({
   );
   // block id for modal
   const [activeBlockId, setActiveBlockId] = useState<number>(-1);
+   */
   // BasicTreeInfo to display in tree popup
   const [activeTreeInfo, setActiveTreeInfo] = useState<BasicTreeInfo>({
     id: NO_SITE_SELECTED,
@@ -87,6 +87,7 @@ const MapView: React.FC<MapViewProps> = ({
   });
 
   // logic for reservation modal to complete action selected by user
+  /*
   const handleOk = async (team?: number) => {
     setShowModal(false);
     switch (reservationType) {
@@ -104,6 +105,7 @@ const MapView: React.FC<MapViewProps> = ({
         break;
     }
   };
+  */
 
   const { windowType } = useWindowDimensions();
 
@@ -326,6 +328,7 @@ const MapView: React.FC<MapViewProps> = ({
         // Initially true while the neighborhoods are shown by themselves
         setNeighborhoodsStyle(true);
         // adds listener so reservation modal appears when block clicked
+        /*
         blocksLayer.addListener('click', (event) => {
           // get status of block based on color
           const status: ReservationModalType = ((): ReservationModalType => {
@@ -345,6 +348,7 @@ const MapView: React.FC<MapViewProps> = ({
           // set id of block
           setActiveBlockId(event.feature.getProperty('block_id'));
         });
+        */
 
         // Check for clicks on neighborhoods and zoom to when clicked on a neighborhood
         neighborhoodsLayer.addListener('click', (event) => {
@@ -499,6 +503,7 @@ const MapView: React.FC<MapViewProps> = ({
       </div>
       <MapDiv id="map" ref={mapRef} />
       <TreePopup treeInfo={activeTreeInfo} popRef={treePopupRef} />
+      {/*
       <ReservationModal
         status={reservationType}
         blockID={activeBlockId}
@@ -506,6 +511,7 @@ const MapView: React.FC<MapViewProps> = ({
         onCancel={() => setShowModal(false)}
         isVisible={showModal}
       />
+      */}
     </>
   );
 };

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -49,6 +49,8 @@ const TreeInfo: React.FC<TreeProps> = ({
   const history = useHistory();
   const location = useLocation<RedirectStateProps>();
 
+  const adopted = siteData.entries[0].adopter !== null;
+
   const getSiteLocation = (): string => {
     // TODO change to siteData.city and remove check for zip after data is cleaned
     let baseLocation = `Boston`;
@@ -106,8 +108,9 @@ const TreeInfo: React.FC<TreeProps> = ({
                       type="primary"
                       size={mobile ? 'middle' : 'large'}
                       onClick={onClickAdopt}
+                      disabled={adopted}
                     >
-                      Adopt
+                      {adopted ? 'Already Adopted' : 'Adopt'}
                     </Button>
                   </>
                 )}

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -45,6 +45,7 @@ const Home: React.FC = () => {
   const greeting = `${HOME_TITLE}${userName}!`;
 
   const links: LinkCardProps[] = [
+    /*
     {
       text: 'My Blocks',
       path: `${Routes.RESERVATIONS}`,
@@ -65,6 +66,7 @@ const Home: React.FC = () => {
       path: `${Routes.TEAM_LEADERBOARD}`,
       background: Backgrounds.IMAGE_FOUR,
     },
+    */
     {
       text: 'My Trees',
       path: `${Routes.MY_TREES}`,
@@ -118,9 +120,11 @@ const Home: React.FC = () => {
                     <List
                       dataSource={links}
                       grid={{ gutter: 1, column: 3 }}
+                      /*
                       pagination={{
                         pageSize: 3,
                       }}
+                       */
                       renderItem={(item: LinkCardProps) => (
                         <LinkCard
                           text={item.text}
@@ -143,9 +147,11 @@ const Home: React.FC = () => {
                     <List
                       dataSource={links}
                       grid={{ gutter: 16, column: 4 }}
+                      /* Remove comment when more links are accessible from home
                       pagination={{
                         pageSize: 4,
                       }}
+                       */
                       renderItem={(item: LinkCardProps) => (
                         <LinkCard
                           text={item.text}

--- a/src/containers/treePage/ducks/reducer.ts
+++ b/src/containers/treePage/ducks/reducer.ts
@@ -11,7 +11,7 @@ import { C4CAction } from '../../../store';
 
 export const initialSiteState: SiteReducerState = {
   siteData: AsyncRequestNotStarted<SiteProps, any>(),
-  stewarshipActivityData: AsyncRequestNotStarted<StewardshipActivities, any>(),
+  stewardshipActivityData: AsyncRequestNotStarted<StewardshipActivities, any>(),
 };
 
 const siteDataReducer = generateAsyncRequestReducer<
@@ -37,8 +37,8 @@ const reducers = (
       return {
         ...state,
         siteData: siteDataReducer(state.siteData, action),
-        stewarshipActivityData: stewarshipActivityReducer(
-          state.stewarshipActivityData,
+        stewardshipActivityData: stewarshipActivityReducer(
+          state.stewardshipActivityData,
           action,
         ),
       };

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -75,7 +75,7 @@ export const getLatestEntry = (
   return [];
 };
 
-export const isTreeAdopted = (
+export const isTreeAdoptedByUser = (
   items: AsyncRequest<AdoptedSites, any>,
   siteId: number,
 ): boolean => {

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -54,6 +54,7 @@ export interface SiteEntry {
   stump?: string;
   treeNotes?: string;
   siteNotes?: string;
+  adopter?: string;
 }
 
 export interface SplitSiteEntries {
@@ -147,7 +148,7 @@ export interface AdoptedSites {
 
 export interface SiteReducerState {
   readonly siteData: AsyncRequest<SiteProps, any>;
-  readonly stewarshipActivityData: AsyncRequest<StewardshipActivities, any>;
+  readonly stewardshipActivityData: AsyncRequest<StewardshipActivities, any>;
 }
 
 export interface ProtectedSitesReducerState {

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -18,7 +18,7 @@ import { LIGHT_GREY } from '../../utils/colors';
 import styled from 'styled-components';
 import {
   getLatestSplitEntry,
-  isTreeAdopted,
+  isTreeAdoptedByUser,
   mapStewardshipToTreeCare,
 } from './ducks/selectors';
 import {
@@ -138,6 +138,7 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
       .unadoptSite(id)
       .then(() => {
         message.success('Unadopted site!');
+        dispatch(getSiteData(id));
         dispatch(getAdoptedSites());
       })
       .catch((err) => {
@@ -151,7 +152,7 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
 
   const doesUserOwnTree: boolean = useSelector((state: C4CState) => {
     if (loggedIn) {
-      return isTreeAdopted(state.adoptedSitesState.adoptedSites, id);
+      return isTreeAdoptedByUser(state.adoptedSitesState.adoptedSites, id);
     } else {
       return false;
     }
@@ -286,7 +287,7 @@ const mapStateToProps = (state: C4CState): TreeProps => {
     tokens: state.authenticationState.tokens,
     siteData: state.siteState.siteData,
     stewardship: mapStewardshipToTreeCare(
-      state.siteState.stewarshipActivityData,
+      state.siteState.stewardshipActivityData,
     ),
     adoptedSites: state.adoptedSitesState.adoptedSites,
   };


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1323610260)
[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1331275997)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Prevents users from accessing pages that are still in development and disables the adopt button if a tree has already been adopted.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Commented out routes we won't be using yet and a few related things (ex. pagination)
- Added `adopter` to SiteEntry to check if a site has an adopter

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->
Updated home links
![image](https://user-images.githubusercontent.com/22990100/121451335-664df200-c96b-11eb-890d-48f59f862021.png)
Disabled adopt button
![image](https://user-images.githubusercontent.com/22990100/121451351-6d750000-c96b-11eb-9037-a41c50c33d3c.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Tried accessing the blocked routes and ensured was redirected to page not found
