### PR TITLE
changed navbar alignment and popup dimensions

### DIFF
--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -54,10 +54,12 @@ const MainLogo = styled.img`
 
 const BostonLogo = styled.img`
   height: 55px;
+  line-height: 0px;
 `;
 
 const C4CLogo = styled.img`
   height: 27px;
+  line-height: 0px;
 `;
 
 const LandingExtraContainer = styled.div`
@@ -98,7 +100,6 @@ const NoHoverShadeButton = styled(Button)`
 
 const LogoCol = styled(Col)`
   height: 100%;
-  line-height: 6vh;
 `;
 
 const NavTitleText = styled.div`
@@ -108,6 +109,7 @@ const NavTitleText = styled.div`
   display: inline-block;
   color: ${MID_GREEN};
   margin-bottom: 10px;
+  line-height: 0px;
 `;
 
 interface NavBarProps {
@@ -130,7 +132,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
 
   const HeaderTitle = () => (
     <NoHoverShadeButton type="text" onClick={() => history.push(Routes.HOME)}>
-      <Row align="bottom">
+      <Row align="middle">
         <Col span={6}>
           <MainLogo src={sfttLogo} alt="icon" />
         </Col>

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -35,6 +35,7 @@ const NavContainer = styled.div`
   background: ${BACKGROUND_GREY};
   color: ${MID_GREEN};
   height: 9vh;
+  min-height: 80px;
   padding: 0;
   overflow: hidden;
 `;
@@ -65,8 +66,8 @@ const C4CLogo = styled.img`
 const LandingExtraContainer = styled.div`
   float: right;
   padding-right: 2vw;
+  padding-top: 22px;
   height: 100%;
-  line-height: 9vh;
 `;
 
 const SignupButton = styled(Button)`

--- a/src/components/treePopup/index.tsx
+++ b/src/components/treePopup/index.tsx
@@ -48,12 +48,11 @@ const PopupBubble = styled.div`
   left: 0;
   transform: translate(-50%, -100%);
   background-color: ${WHITE};
-  width: 250px;
-  max-height: 150px;
+  min-width: 250px;
+  min-height: 150px;
   padding: 7px 15px;
   border-radius: 2px;
   box-shadow: 0px 2px 10px 1px ${BLACK}50;
-  overflow-y: scroll;
 `;
 
 const TreeTitle = styled(Paragraph)`


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1401865519)
[Monday.com Ticket](https://code4community-team.monday.com/boards/925293934/views/18904377/pulses/1398345228)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Formatting fixes to map popups on the mapView look nicer. Removes the unnecessary horizontal and vertical scrolling. Also changed the alignment of the nav bar logos so they do not get cut off when a screen is short

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

I added a min-height to the tree popups to set their size and I removed the max height to prevent text from being cut off. The common name and address already have length limits enforced in the database so there is not a concern about a huge chunk of text in the popup. 

For the navbar I changed the row alignment from bottom to middle and set a min height for the navbar so if the user makes their window short the navbar won't cut off the logos. I also made the padding for the login and signup buttons a constant to prevent them from moving towards the top of the screen as the window gets shorter.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![format](https://user-images.githubusercontent.com/19194912/123149786-a1eac080-d42f-11eb-8484-c3b603245ec4.PNG)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

I changed the size of the screen both vertically and horizontally and I checked on many trees to ensure the popup did not have weird proportions 
