### PR TITLE
Displays information on tree page if common name is unknown

### DIFF
--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -68,14 +68,19 @@ const TreeInfo: React.FC<TreeProps> = ({
   return (
     <>
       <TreeHeader>
-        {siteData.entries[0].commonName && (
+        {
           <PageHeader
-            pageTitle={siteData.entries[0].commonName}
+            // Either commonName or 'Unknown Species' if no commonName exists
+            pageTitle={
+              siteData.entries[0].commonName
+                ? siteData.entries[0].commonName
+                : 'Unknown Species'
+            }
             isMobile={mobile}
             pageSubtitle={getSiteLocation()}
             subtitlecolor={MID_GREEN}
           />
-        )}
+        }
       </TreeHeader>
 
       {(() => {


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1fqtbjh)

Allows tree pages to have headers if they have no common name or species.  

## This PR

Changed logic for displaying header.  Formerly header was dependent on common name existing, replaced with ? operator. 

## Screenshots

![image](https://user-images.githubusercontent.com/58788642/134579562-e18f37d7-54c7-4c15-8f50-10c82e700320.png)

## Verification Steps

Compared https://map.treeboston.org/tree/3215900 and http://localhost:3000/tree/3215900: former has a blank header where local version contains address information 
