### PR TITLE
Check site entry

### DIFF
--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -261,22 +261,35 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
                     );
                 }
               })()}
-              <CenterDiv>
-                <EntryList
-                  entries={latestEntry.main}
-                  canHide={false}
-                  title="About This Tree"
-                />
-              </CenterDiv>
-              <CenterDiv>
-                <EntryList
-                  entries={latestEntry.extra}
-                  canHide={true}
-                  hideText="Hide Extra Tree Details"
-                  showText="Click to Read More About This Tree"
-                  title="Additional Information"
-                />
-              </CenterDiv>
+              {console.log(latestEntry)}
+              {/* Display main entries if there are any. Otherwise, display message that no entries have been collected */}
+              {latestEntry.main.length ? (
+                <>
+                  <CenterDiv>
+                    <EntryList
+                      entries={latestEntry.main}
+                      canHide={false}
+                      title="About This Tree"
+                    />
+                  </CenterDiv>
+                  {/* Display extra entries if there are any, given that there are main entries */}
+                  {latestEntry.extra.length !== 0 && (
+                    <CenterDiv>
+                      <EntryList
+                        entries={latestEntry.extra}
+                        canHide={true}
+                        hideText="Hide Extra Tree Details"
+                        showText="Click to Read More About This Tree"
+                        title="Additional Information"
+                      />
+                    </CenterDiv>
+                  )}
+                </>
+              ) : (
+                <Title level={2}>
+                  No data has been collected about this site.
+                </Title>
+              )}
             </>
           )}
           {asyncRequestIsFailed(siteData) && (

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -261,7 +261,6 @@ const TreePage: React.FC<TreeProps> = ({ siteData, stewardship, tokens }) => {
                     );
                 }
               })()}
-              {console.log(latestEntry)}
               {/* Display main entries if there are any. Otherwise, display message that no entries have been collected */}
               {latestEntry.main.length ? (
                 <>


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1dk448x)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Check to make sure that a site has at least one entry on the tree page.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Add a check to ensure that a site has at least one site entry on the tree page and, if not, display the message "No data has been collected about this site." instead.

Site entries are divided into two categories (`main` and `extra`) and there are four possible cases:
1. Site has both main and extra entries &#8594; display both entries
2. Site has only main entries &#8594; only display main entries
3. Site has only extra entries &#8594; display message "No data has been collected about this site."
4. Site has neither main nor extra entries &#8594; display message "No data has been collected about this site."

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Case 2 (site has only main entries):
![image](https://user-images.githubusercontent.com/33704204/135962693-4b1a0db1-7094-4d6c-a190-95a0285b73d6.png)

Cases 3 and 4 (site has only extra entries OR site has neither main nor extra entries):
![image](https://user-images.githubusercontent.com/33704204/135962881-ec7c4f27-607a-4e34-a86e-7d374c962cf8.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visual verification that the entries or message displayed are correct in all four cases on Firefox. Ran `npm run check` and `npm run test`.