### PR TITLE
Color neighborhoods by canopy coverage

### DIFF
--- a/src/components/mapPageComponents/logic/style.ts
+++ b/src/components/mapPageComponents/logic/style.ts
@@ -1,5 +1,6 @@
 import {
   BLACK,
+  DARK_GREY,
   MAP_GREEN,
   MAP_RED,
   MAP_YELLOW,
@@ -76,9 +77,9 @@ export function setBlocksStyle(
 }
 
 /**
- * Sets the style of the neighborhoods layer according to its completion percentage and updates the visibility of neighborhood markers.
+ * Sets the style of the neighborhoods layer according to its canopy coverage and updates the visibility of neighborhood markers.
  * @param neighborhoodsLayer the layer
- *  @param markers the array containing the neighborhood markers
+ * @param markers the array containing the neighborhood markers
  * @param v true to make the layer visible, false to make it invisible
  */
 export function setNeighborhoodsStyle(
@@ -90,9 +91,9 @@ export function setNeighborhoodsStyle(
   neighborhoodsLayer.setStyle((feature) => {
     return {
       fillColor: `${MAP_GREEN}`,
-      fillOpacity: (feature.getProperty('neighborhood_id') / 100) * 2 + 0.1, // TODO: replace this with completion percentage
+      fillOpacity: feature.getProperty('canopy_coverage'),
       strokeWeight: 1,
-      strokeColor: `${WHITE}`,
+      strokeColor: `${DARK_GREY}`,
       visible: v,
     };
   });


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1ddknzg)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Colors neighborhoods by their canopy coverage (as requested by SFTT)

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

`fillOpacity` is based on `canopy_coverage` instead of the previous filler logic
Changed stroke color from white to dark grey to make the neighborhoods more distinct

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![image](https://user-images.githubusercontent.com/22990100/138625762-c05c6377-2fa7-482e-aede-405ef4989893.png)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually confirmed the neighborhoods' opacity matched their canopy coverage
