### PR TITLE
Missing X-Access-Token

### DIFF
--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -13,7 +13,7 @@ const AppAxiosInstance: AxiosInstance = axios.create({
   },
 });
 
-const INVALID_ACCESS_TOKEN: string = 'Given access token is expired or invalid';
+const INVALID_ACCESS_TOKEN = 'Given access token is expired or invalid';
 
 const responseErrorInterceptor = (error: AxiosError) => {
   const originalRequest = {
@@ -56,5 +56,14 @@ AppAxiosInstance.interceptors.response.use(
   (response) => response,
   responseErrorInterceptor,
 );
+
+AppAxiosInstance.interceptors.request.use((config) => {
+  const tokens: UserAuthenticationReducerState['tokens'] = store.getState()
+    .authenticationState.tokens;
+  if (asyncRequestIsComplete(tokens)) {
+    config.headers['X-Access-Token'] = tokens.result.accessToken;
+  }
+  return config;
+});
 
 export default AppAxiosInstance;


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/250xh4q)

There's an issue where some requests (I think those that aren't dispatched) result in the error "Missing required request header: X-Access-Token" unless made immediately after login.

![image](https://user-images.githubusercontent.com/22990100/148843824-902c16f6-d90f-421e-b7f4-0bd4e66a9879.png)

## This PR

Error occurs because the access token in store isn't applied to the header for each request. Existing code attempts to do this after login by setting the axios instance config defaults

`AppAxiosInstance.defaults.headers['X-Access-Token'] =  response.accessToken;`

but the token is not appplied to every request, only the next request after login.

This PR creates an interceptor that intercepts each axios request, gets the access token from store, and applies the header (if user is logged in).