### PR TITLE
Reflect updated back end naming convention

### DIFF
--- a/src/components/mapComponents/logic/event.ts
+++ b/src/components/mapComponents/logic/event.ts
@@ -77,7 +77,7 @@ export function addShowReservationModal(): void {
   blocksLayer.addListener('click', (event) => {
     // get status of block based on color
     const status: ReservationModalType = ((): ReservationModalType => {
-      switch (event.feature.getProperty('block_id') % 10) {
+      switch (event.feature.getProperty('blockId') % 10) {
         case 1:
           return ReservationModalType.TAKEN;
         case 0:
@@ -91,7 +91,7 @@ export function addShowReservationModal(): void {
     // set status of block
     setReservationType(status);
     // set id of block
-    setActiveBlockId(event.feature.getProperty('block_id'));
+    setActiveBlockId(event.feature.getProperty('blockId'));
   });
 }
  */

--- a/src/components/mapComponents/logic/style.ts
+++ b/src/components/mapComponents/logic/style.ts
@@ -50,11 +50,11 @@ export function setBlocksStyle(
       let color = `${MAP_GREEN}`;
 
       // Use this for coloring reserved/completed blocks a different color
-      if (feature.getProperty('block_id') % 10 === 0) {
+      if (feature.getProperty('blockId') % 10 === 0) {
         color = `${MAP_YELLOW}`;
       }
 
-      if (feature.getProperty('block_id') % 10 === 1) {
+      if (feature.getProperty('blockId') % 10 === 1) {
         color = `${MAP_RED}`;
       }
 
@@ -91,7 +91,7 @@ export function setNeighborhoodsStyle(
   neighborhoodsLayer.setStyle((feature) => {
     return {
       fillColor: `${MAP_GREEN}`,
-      fillOpacity: feature.getProperty('canopy_coverage'),
+      fillOpacity: feature.getProperty('canopyCoverage'),
       strokeWeight: 1,
       strokeColor: `${DARK_GREY}`,
       visible: v,


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/28ry9d3)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

SFTT noticed the neighborhoods of the map all had the same opacity.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Found the bug was caused because the name passed to `getProperty` did not exist, making the method return undefined and thus setting the opacity to the default for all neighborhoods. This is a result of the updated back end naming conventions. Changed names passed to `getProperty` to camelCase to reflect the change from snake_case in the back end.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

Properly styled neighborhoods:
![image](https://user-images.githubusercontent.com/22990100/151384390-9abd2656-62ea-416b-b9ba-d78a64b6bb31.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually confirmed the neighborhood opacities are correct.
