### PR TITLE
Refresh Updates Redux Store

### DIFF
--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
-import store, { LOCALSTORAGE_STATE_KEY } from '../store';
+import store from '../store';
 import { asyncRequestIsComplete } from '../utils/asyncRequest';
 import { UserAuthenticationReducerState } from './ducks/types';
 import { isTokenValid } from './ducks/selectors';
-import AuthClient from './authClient';
+import { logout, refresh } from './ducks/thunks';
+import authClient from './authClient';
+import protectedApiClient from '../api/protectedApiClient';
 
 const AppAxiosInstance: AxiosInstance = axios.create({
   baseURL: process.env.REACT_APP_API_DOMAIN,
@@ -12,6 +14,11 @@ const AppAxiosInstance: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+const userAuthenticationExtraArgs = {
+  authClient,
+  protectedApiClient,
+};
 
 const INVALID_ACCESS_TOKEN = 'Given access token is expired or invalid';
 
@@ -31,13 +38,12 @@ const responseErrorInterceptor = (error: AxiosError) => {
     isTokenValid(tokens.result.refreshToken) &&
     !(error.config as any)?._retry
   ) {
-    return AuthClient.refresh(tokens.result.refreshToken).then(
-      ({ freshAccessToken }) => {
-        AppAxiosInstance.defaults.headers['X-Access-Token'] = freshAccessToken;
-        originalRequest.headers['X-Access-Token'] = freshAccessToken;
-        return AppAxiosInstance(originalRequest);
-      },
+    refresh(tokens.result.refreshToken)(
+      store.dispatch,
+      store.getState,
+      userAuthenticationExtraArgs,
     );
+    return AppAxiosInstance(originalRequest);
   }
   if (
     asyncRequestIsComplete(tokens) &&
@@ -45,9 +51,7 @@ const responseErrorInterceptor = (error: AxiosError) => {
     error?.response?.data === INVALID_ACCESS_TOKEN &&
     !isTokenValid(tokens.result.refreshToken)
   ) {
-    AuthClient.logout(tokens.result.refreshToken).then(() => {
-      localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
-    });
+    logout()(store.dispatch, store.getState, userAuthenticationExtraArgs);
   }
   return Promise.reject(error);
 };

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -1,5 +1,6 @@
 import {
   LoginRequest,
+  RefreshTokenResponse,
   SignupRequest,
   TokenPayload,
   UserAuthenticationThunkAction,
@@ -22,6 +23,27 @@ export const login = (
         AppAxiosInstance.defaults.headers['X-Access-Token'] =
           response.accessToken;
         dispatch(authenticateUser.loaded(response));
+      })
+      .catch((error) => {
+        dispatch(authenticateUser.failed(error.response.data));
+      });
+  };
+};
+
+export const refresh = (
+  refreshToken: string,
+): UserAuthenticationThunkAction<void> => {
+  return (dispatch, getState, { authClient }): Promise<void> => {
+    dispatch(authenticateUser.loading());
+    return authClient
+      .refresh(refreshToken)
+      .then((refreshTokenResponse: RefreshTokenResponse) => {
+        dispatch(
+          authenticateUser.loaded({
+            accessToken: refreshTokenResponse.freshAccessToken,
+            refreshToken,
+          }),
+        );
       })
       .catch((error) => {
         dispatch(authenticateUser.failed(error.response.data));

--- a/src/store.ts
+++ b/src/store.ts
@@ -113,7 +113,7 @@ export const initialStoreState: C4CState = {
   adoptedSitesState: initialProtectedSiteState,
 };
 
-export const LOCALSTORAGE_STATE_KEY: string = 'state';
+export const LOCALSTORAGE_STATE_KEY = 'state';
 
 const loadStateFromLocalStorage = (): C4CState | undefined => {
   try {


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1x52pz7)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Ensures the access token is refreshed or the user is logged out when access token expires.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

Previously, our way of refreshing never actually updated the store with the fresh access token–instead, axios would always catch the expired access token error, get a new access token, and apply that token to the next call (re-making the original request). This ticket creates a refresh thunk to update the Redux store via dispatch. The axios response interceptor uses the refresh thunk and logout thunk instead of calling authClient directly to ensure the store is updated appropriately.

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 

Wrote tests for the new refresh thunk and ran the front end/back end to check that refresh worked after the access token expired.