### PR TITLE
Copy email in reports to clipboard

### DIFF
--- a/src/components/copyText/index.tsx
+++ b/src/components/copyText/index.tsx
@@ -7,6 +7,10 @@ interface CopyTextProps {
   readonly onCopy?: (text: string) => Promise<void>;
 }
 
+/**
+ * Writes to the system clipboard using the [Clipboard Api](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).
+ * @param text the string to copy to the clipboard
+ */
 export const copyToClipboard = (text: string): Promise<void> => {
   return navigator.clipboard.writeText(text);
 };

--- a/src/components/copyText/index.tsx
+++ b/src/components/copyText/index.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Button, Tooltip } from 'antd';
+import styled from 'styled-components';
+
+interface CopyTextProps {
+  readonly text: string;
+  readonly onCopy?: (text: string) => Promise<void>;
+}
+
+export const copyToClipboard = (text: string): Promise<void> => {
+  return navigator.clipboard.writeText(text);
+};
+
+const ClickableText = styled(Button)`
+  border: none;
+  padding: 0;
+  background: inherit;
+  box-shadow: none;
+
+  &:hover {
+    background: inherit;
+  }
+`;
+
+const CopyText: React.FC<CopyTextProps> = ({
+  text,
+  onCopy = copyToClipboard,
+}) => {
+  const [copiedFeedback, setCopiedFeedback] = useState('Copied to clipboard!');
+
+  const onClick = () => {
+    onCopy(text).catch(() => {
+      setCopiedFeedback('Browser does not support copying to clipboard.');
+    });
+  };
+
+  return (
+    <Tooltip title={copiedFeedback} trigger={'click'}>
+      <ClickableText onClick={onClick}>{text}</ClickableText>
+    </Tooltip>
+  );
+};
+
+export default CopyText;

--- a/src/components/copyText/test/copyText.test.tsx
+++ b/src/components/copyText/test/copyText.test.tsx
@@ -1,0 +1,50 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import CopyText, { copyToClipboard } from '../index';
+import React from 'react';
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+describe('copyText tests', () => {
+  describe('copyToClipboard test', () => {
+    it('writes to clipboard', async () => {
+      await copyToClipboard('test copy to clipboard');
+      expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'test copy to clipboard',
+      );
+    });
+  });
+
+  describe('onClick tests', () => {
+    it('displays success feedback on copy', async () => {
+      const mockCopySuccess = jest.fn().mockImplementation(() => {
+        return Promise.resolve();
+      });
+
+      render(<CopyText text={'test'} onCopy={mockCopySuccess} />);
+      fireEvent.click(screen.getByText('test'));
+      expect(mockCopySuccess).toHaveBeenCalledTimes(1);
+      expect(screen.queryByText('Copied to clipboard!')).toBeInTheDocument();
+    });
+
+    it('displays error on copy fail', async () => {
+      const mockCopyFail = jest.fn().mockImplementation(() => {
+        return Promise.reject();
+      });
+
+      render(<CopyText text={'fail'} onCopy={mockCopyFail} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('fail'));
+      });
+      expect(mockCopyFail).toHaveBeenCalledTimes(1);
+      expect(
+        screen.queryByText('Browser does not support copying to clipboard.'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/copyText/test/copyText.test.tsx
+++ b/src/components/copyText/test/copyText.test.tsx
@@ -2,6 +2,10 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import CopyText, { copyToClipboard } from '../index';
 import React from 'react';
 
+/*
+since Jest tests run in JSDOM environment, we have to define the navigator properties to use navigator.clipboard.writeText
+(see more at https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom)
+ */
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(),

--- a/src/components/tables/adoptionReportTable/index.tsx
+++ b/src/components/tables/adoptionReportTable/index.tsx
@@ -3,6 +3,7 @@ import { AdoptionReportEntry } from '../../../containers/reports/ducks/types';
 import { Table } from 'antd';
 import SiteLink from '../siteLink';
 import { dateSorter, DESCEND_ORDER } from '../utils';
+import CopyText from '../../copyText';
 
 interface AdoptionReportTableProps {
   readonly adoptionReportEntries: AdoptionReportEntry[];
@@ -32,6 +33,7 @@ const AdoptionReportTable: React.FC<AdoptionReportTableProps> = ({
         title={"Adopter's Email"}
         dataIndex={'email'}
         key={'email'}
+        render={(email: string) => <CopyText text={email} />}
       />
       <Table.Column
         title={'Date Adopted'}

--- a/src/components/tables/stewardshipReportTable/index.tsx
+++ b/src/components/tables/stewardshipReportTable/index.tsx
@@ -4,6 +4,7 @@ import { Table } from 'antd';
 import SiteLink from '../siteLink';
 import { dateSorter, DESCEND_ORDER } from '../utils';
 import Tags from '../tags';
+import CopyText from '../../copyText';
 
 interface StewardshipReportTableProps {
   readonly stewardshipReportTableEntries: StewardshipReportTableEntry[];
@@ -31,6 +32,7 @@ const StewardshipReportTable: React.FC<StewardshipReportTableProps> = ({
         title={"Adopter's Email"}
         dataIndex={'email'}
         key={'email'}
+        render={(email: string) => <CopyText text={email} />}
       />
       <Table.Column
         title={'Date Performed'}


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/28t1r2h)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Allows admins to easily copy the emails listed in the reports.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Created a new component, ClickableText, that (by default) copies the displayed text to the clipboard.
- Uses the [ClipboardAPI](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API), which is not supported on Internet Explorer - users will be notified if their browser doesn't support copying
- Takes `onCopy` as a prop for extension + testing purposes

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 

![image](https://user-images.githubusercontent.com/22990100/151895025-7119661a-46ef-4008-bd28-6735594f965b.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Wrote tests to check the logic and error handling.
