### PR TITLE
Open tree page in a new tab

### DIFF
--- a/src/components/mapComponents/maps/mapWithPopup/index.tsx
+++ b/src/components/mapComponents/maps/mapWithPopup/index.tsx
@@ -186,11 +186,7 @@ const MapWithPopup: React.FC<MapWithPopupProps> = ({
         />
       </div>
       <MapDiv id="map" ref={mapRef} />
-      <TreePopup
-        treeInfo={activeTreeInfo}
-        popRef={treePopupRef}
-        mobile={false}
-      />
+      <TreePopup treeInfo={activeTreeInfo} popRef={treePopupRef} />
       {children}
     </>
   );

--- a/src/components/treePopup/index.tsx
+++ b/src/components/treePopup/index.tsx
@@ -101,14 +101,12 @@ interface TreePopupProps {
   popRef: React.RefObject<HTMLDivElement>;
   treeInfo: BasicTreeInfo;
   returnTo?: Routes;
-  mobile: boolean;
 }
 
 const TreePopup: React.FC<TreePopupProps> = ({
   popRef,
   treeInfo,
   returnTo,
-  mobile,
 }) => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
@@ -123,9 +121,6 @@ const TreePopup: React.FC<TreePopupProps> = ({
   }, [treeInfo]);
 
   const returnState = returnTo && { destination: returnTo };
-  // if on mobile or no return destination specified, open in new tab
-  // location state is only saved within the same tab, does not work when opening new tab
-  const target = !mobile || (!returnState && '_blank');
 
   return (
     <PopupContainer ref={popRef}>
@@ -168,7 +163,7 @@ const TreePopup: React.FC<TreePopupProps> = ({
                       <GreenLinkButton
                         to={`${ParameterizedRouteBases.TREE}${treeInfo.id}`}
                         state={returnState}
-                        target={target}
+                        target="_blank"
                       >
                         More Info
                       </GreenLinkButton>


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1x52qae)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Open the tree page in a new tab after clicking "More Info" on the map popup.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Pass in "_blank" as `target`. The change that led to this bug was through #113 (just a little confused as to why this change was initially required - would this ticket break how the popup and return button function on mobile?).

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Clicking the "More Info" button on the tree popup opens tree page in a new tab (at least on desktop).
![image](https://user-images.githubusercontent.com/33704204/154817992-586f7b5e-4ad9-436e-bded-a58d66c61c03.png)

Clicking on the "Return to Tree Map" button redirects to the main page with the map with the right location and street-level zoom.
![image](https://user-images.githubusercontent.com/33704204/154818006-61bee314-9bbc-499f-b0a7-53adc5b660ae.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Tested that the tree page opens up in a new page and that clicking the "Return to Tree Map" button redirects to the map page with the correct location. Not tested on mobile.
