### PR TITLE
Improve forgot password page

### DIFF
--- a/src/assets/content.tsx
+++ b/src/assets/content.tsx
@@ -45,7 +45,7 @@ export const LOGIN_HEADER = 'Welcome back!';
 export const LOGIN_BODY =
   "Thanks for volunteering with us! Your work is vital in supporting the health of Boston's urban forest. " +
   "Let's get back to those trees.";
-export const LOGIN_ERROR = 'The username or email you entered was incorrect.';
+export const LOGIN_ERROR = 'The email or password you entered was incorrect.';
 
 // Signup
 export const SIGNUP_TITLE = 'Sign Up';

--- a/src/containers/forgotPassword/index.tsx
+++ b/src/containers/forgotPassword/index.tsx
@@ -12,19 +12,13 @@ import { enterEmailRules } from '../../utils/formRules';
 const ForgotPassword: React.FC = () => {
   const { windowType } = useWindowDimensions();
 
-  const [submittedEmail, setSubmittedEmail] = useState(false);
   const [email, setEmail] = useState('');
 
   const onFinish = (values: ForgotPasswordRequest) => {
-    authClient
-      .forgotPassword(values)
-      .catch(() => {
-        return;
-      })
-      .finally(() => {
-        setSubmittedEmail(true);
-        setEmail(values.email);
-      });
+    setEmail(values.email);
+    authClient.forgotPassword(values).catch(() => {
+      return;
+    });
   };
 
   return (
@@ -41,7 +35,7 @@ const ForgotPassword: React.FC = () => {
           pageTitle="Forgot your password?"
           isMobile={isMobile(windowType)}
         />
-        {!submittedEmail ? (
+        {email === '' ? (
           <>
             <Typography.Title level={4}>
               Please enter your email and we will send you the password reset

--- a/src/containers/forgotPassword/index.tsx
+++ b/src/containers/forgotPassword/index.tsx
@@ -13,19 +13,17 @@ const ForgotPassword: React.FC = () => {
   const { windowType } = useWindowDimensions();
 
   const [submittedEmail, setSubmittedEmail] = useState(false);
-  const [userNotFound, setUserNotFound] = useState(false);
-  const [form] = Form.useForm();
+  const [email, setEmail] = useState('');
 
   const onFinish = (values: ForgotPasswordRequest) => {
     authClient
       .forgotPassword(values)
-      .then(() => {
-        setSubmittedEmail(true);
-        setUserNotFound(false);
-      })
       .catch(() => {
-        setUserNotFound(true);
-        form.resetFields();
+        return;
+      })
+      .finally(() => {
+        setSubmittedEmail(true);
+        setEmail(values.email);
       });
   };
 
@@ -43,19 +41,13 @@ const ForgotPassword: React.FC = () => {
           pageTitle="Forgot your password?"
           isMobile={isMobile(windowType)}
         />
-        {!submittedEmail || userNotFound ? (
+        {!submittedEmail ? (
           <>
             <Typography.Title level={4}>
               Please enter your email and we will send you the password reset
               instructions to the email address for this account.
             </Typography.Title>
-            <Form form={form} name="forgotPassword" onFinish={onFinish}>
-              {userNotFound && (
-                <Typography.Title level={4}>
-                  We couldn't find an account associated with the given email.
-                  Please try again.
-                </Typography.Title>
-              )}
+            <Form name="forgotPassword" onFinish={onFinish}>
               <Form.Item name="email" rules={enterEmailRules}>
                 <Input placeholder="Email" />
               </Form.Item>
@@ -67,11 +59,10 @@ const ForgotPassword: React.FC = () => {
             </Form>
           </>
         ) : (
-          <>
-            <Typography.Title level={4}>
-              The password reset instructions have been sent to your email!
-            </Typography.Title>
-          </>
+          <Typography.Title level={4}>
+            If an account is registered under {email}, we have sent you a link
+            to reset your password.
+          </Typography.Title>
         )}
       </ContentContainer>
     </>

--- a/src/containers/forgotPassword/index.tsx
+++ b/src/containers/forgotPassword/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import authClient from '../../auth/authClient';
 import { ForgotPasswordRequest } from '../../auth/ducks/types';
 import useWindowDimensions from '../../components/windowDimensions';
-import { Button, Form, Input } from 'antd';
+import { Button, Form, Input, Typography } from 'antd';
 import PageHeader from '../../components/pageHeader';
 import { ContentContainer } from '../../components/themedComponents';
 import { isMobile } from '../../utils/isCheck';
@@ -12,16 +12,23 @@ import { enterEmailRules } from '../../utils/formRules';
 const ForgotPassword: React.FC = () => {
   const { windowType } = useWindowDimensions();
 
+  const [submittedEmail, setSubmittedEmail] = useState(false);
+  const [userNotFound, setUserNotFound] = useState(false);
+  const [form] = Form.useForm();
+
   const onFinish = (values: ForgotPasswordRequest) => {
     authClient
       .forgotPassword(values)
       .then(() => {
-        alert('Successfully sent forgot password request!');
+        setSubmittedEmail(true);
+        setUserNotFound(false);
       })
-      .catch((err) => {
-        alert('Forgot password request unsuccessful!');
+      .catch(() => {
+        setUserNotFound(true);
+        form.resetFields();
       });
   };
+
   return (
     <>
       <Helmet>
@@ -33,19 +40,39 @@ const ForgotPassword: React.FC = () => {
       </Helmet>
       <ContentContainer>
         <PageHeader
-          pageTitle="Forgot Password"
+          pageTitle="Forgot your password?"
           isMobile={isMobile(windowType)}
         />
-        <Form name="forgotPassword" onFinish={onFinish}>
-          <Form.Item name="email" rules={enterEmailRules}>
-            <Input placeholder="Email" />
-          </Form.Item>
-          <Form.Item>
-            <Button type="primary" htmlType="submit" size="large">
-              Submit
-            </Button>
-          </Form.Item>
-        </Form>
+        {!submittedEmail || userNotFound ? (
+          <>
+            <Typography.Title level={4}>
+              Please enter your email and we will send you the password reset
+              instructions to the email address for this account.
+            </Typography.Title>
+            <Form form={form} name="forgotPassword" onFinish={onFinish}>
+              {userNotFound && (
+                <Typography.Title level={4}>
+                  We couldn't find an account associated with the given email.
+                  Please try again.
+                </Typography.Title>
+              )}
+              <Form.Item name="email" rules={enterEmailRules}>
+                <Input placeholder="Email" />
+              </Form.Item>
+              <Form.Item>
+                <Button type="primary" htmlType="submit" size="large">
+                  Submit
+                </Button>
+              </Form.Item>
+            </Form>
+          </>
+        ) : (
+          <>
+            <Typography.Title level={4}>
+              The password reset instructions have been sent to your email!
+            </Typography.Title>
+          </>
+        )}
       </ContentContainer>
     </>
   );


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1gewz96)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Improve the forgot password page so that it displays appropriate messages instead of alert popups and console logs when the password reset request is successful or not. Upon a successful request, update the page to prevent the user from submitting multiple requests.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Initial screen:
![image](https://user-images.githubusercontent.com/33704204/159179656-bb697763-09e9-4454-a2f1-8162a4a4942d.png)

User submits non-existent email:
![image](https://user-images.githubusercontent.com/33704204/159179675-7a861f5c-0b6d-4b77-bd58-da81db181fbc.png)

User submits correct email:
![image](https://user-images.githubusercontent.com/33704204/159179702-360a3a68-f556-477a-b58d-df368b2a0eb5.png)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Verify that the messages shown are as expected when the user submits incorrect and correct email addresses.