### PR TITLE
Display only streets and parks in map

### DIFF
--- a/src/components/mapComponents/constants.tsx
+++ b/src/components/mapComponents/constants.tsx
@@ -64,6 +64,8 @@ export const SITE_OPTIONS: { label: ReactNode; value: string }[] = [
   },
 ];
 
+// Relevant documentation: https://developers.google.com/maps/documentation/javascript/style-reference
+// Removes the map's labels for all POIs (points of interest) such as businesses and schools except parks
 export const LIGHT_MAP_STYLES: google.maps.MapTypeStyle[] = [
   {
     featureType: 'poi',

--- a/src/components/mapComponents/constants.tsx
+++ b/src/components/mapComponents/constants.tsx
@@ -63,3 +63,22 @@ export const SITE_OPTIONS: { label: ReactNode; value: string }[] = [
     value: 'Open',
   },
 ];
+
+export const LIGHT_MAP_STYLES: google.maps.MapTypeStyle[] = [
+  {
+    featureType: 'poi',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'poi.park',
+    stylers: [
+      {
+        visibility: 'on',
+      },
+    ],
+  },
+];

--- a/src/components/mapComponents/maps/treeMap/index.tsx
+++ b/src/components/mapComponents/maps/treeMap/index.tsx
@@ -8,7 +8,7 @@ import {
   SiteGeoData,
 } from '../../ducks/types';
 import { NO_SITE_SELECTED } from '../../../treePopup';
-import { BOSTON } from '../../constants';
+import { BOSTON, LIGHT_MAP_STYLES } from '../../constants';
 import { addHandleZoomChange, getImageSize } from '../../logic/event';
 import { initSiteView } from '../../logic/init';
 import { CheckboxValueType } from 'antd/es/checkbox/Group';
@@ -60,6 +60,10 @@ const TreeMap: React.FC<TreeMapProps> = ({
     };
 
     setLoadedMapData(setMapData);
+
+    mapData.map.setOptions({
+      styles: LIGHT_MAP_STYLES,
+    });
 
     return setMapData;
   };


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/27pkmw3)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Remove names of buildings and other text so that the map mostly just displays street and park names.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Change the options for the map so that it doesn't display names of POIs (points of interest) except for parks.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![image](https://user-images.githubusercontent.com/33704204/161440114-48f7216c-0b39-43d9-a37e-bf2763d2b323.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually tested that the map mostly only displays street and park names on both desktop and mobile in Chrome and Firefox.