### PR TITLE
Auth Error Interceptor

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,27 @@
 import { TokenPayload, UserData } from './auth/ducks/types';
+import { AxiosError } from 'axios';
+import { AdminApiClientRoutes } from './api/protectedApiClient';
 
 // constants to use in tests
-export const mockTokenResponse: TokenPayload = {
-  accessToken:
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjNGMiLCJleHAiOjE2MDQ4NzIwODIsInVzZXJuYW1lIjoiamFja2JsYW5jIn0.k0D1rySdVqVatWsjdA4i1YYq-7glzrL3ycSQwz-5zLU',
-  refreshToken:
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjNGMiLCJleHAiOjE2MDU0NzUwODIsInVzZXJuYW1lIjoiamFja2JsYW5jIn0.FHgEdtz16H5u7mtTqE81N4PUsnzjvwdaJ4GK_jdLWAY',
+export const BASE_URL = 'http://localhost';
+
+export const accessToken =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjNGMiLCJleHAiOjE2MDQ4NzIwODIsInVzZXJuYW1lIjoiamFja2JsYW5jIn0.k0D1rySdVqVatWsjdA4i1YYq-7glzrL3ycSQwz-5zLU';
+
+// invalid refresh token component
+export const invalidExp = 0;
+
+// valid refresh token component
+export const validExp = Date.now() * 1000 + 1000;
+
+export const mockTokenResponse = (expDate: number): TokenPayload => {
+  return {
+    accessToken,
+    refreshToken:
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.' +
+      btoa('{"iss":"c4c","exp":' + expDate + ',"username":"spain"}') +
+      '.FHgEdtz16H5u7mtTqE81N4PUsnzjvwdaJ4GK_jdLWAY',
+  };
 };
 
 export const mockUserDataResponse: UserData = {
@@ -13,6 +29,28 @@ export const mockUserDataResponse: UserData = {
   lastName: 'Last',
   email: 'test@email.com',
   username: 'user',
+};
+
+export const mockExpiredToken: AxiosError = {
+  code: '',
+  config: {
+    url: AdminApiClientRoutes.GET_ADOPTION_REPORT,
+    baseURL: BASE_URL,
+  },
+  isAxiosError: false,
+  message: '',
+  name: '',
+  request: undefined,
+  response: {
+    status: 401,
+    data: 'Given access token is expired or invalid',
+    statusText: '',
+    config: {},
+    headers: undefined,
+  },
+  toJSON: () => {
+    return mockExpiredToken;
+  },
 };
 
 test('can run tests', () => {

--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -1,11 +1,12 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
-import store from '../store';
+import store, { LOCALSTORAGE_STATE_KEY } from '../store';
 import { asyncRequestIsComplete } from '../utils/asyncRequest';
 import { UserAuthenticationReducerState } from './ducks/types';
 import { isTokenValid } from './ducks/selectors';
 import { logout, refresh } from './ducks/thunks';
 import authClient from './authClient';
 import protectedApiClient from '../api/protectedApiClient';
+import history from '../history';
 
 const AppAxiosInstance: AxiosInstance = axios.create({
   baseURL: process.env.REACT_APP_API_DOMAIN,
@@ -58,7 +59,9 @@ export const responseErrorInterceptor = async (
     error?.response?.data === INVALID_ACCESS_TOKEN &&
     !isTokenValid(tokens.result.refreshToken)
   ) {
-    logout()(store.dispatch, store.getState, userAuthenticationExtraArgs);
+    await logout()(store.dispatch, store.getState, userAuthenticationExtraArgs);
+    localStorage.removeItem(LOCALSTORAGE_STATE_KEY);
+    history.go(0);
   }
   return Promise.reject(error);
 };

--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance } from 'axios';
+import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import store from '../store';
 import { asyncRequestIsComplete } from '../utils/asyncRequest';
 import { UserAuthenticationReducerState } from './ducks/types';
@@ -22,7 +22,9 @@ const userAuthenticationExtraArgs = {
 
 const INVALID_ACCESS_TOKEN = 'Given access token is expired or invalid';
 
-const responseErrorInterceptor = (error: AxiosError) => {
+export const responseErrorInterceptor = async (
+  error: AxiosError,
+): Promise<AxiosResponse> => {
   const originalRequest = {
     ...error.config,
     _retry: true,
@@ -38,7 +40,7 @@ const responseErrorInterceptor = (error: AxiosError) => {
     isTokenValid(tokens.result.refreshToken) &&
     !(error.config as any)?._retry
   ) {
-    refresh(tokens.result.refreshToken)(
+    await refresh(tokens.result.refreshToken)(
       store.dispatch,
       store.getState,
       userAuthenticationExtraArgs,

--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -22,6 +22,11 @@ const userAuthenticationExtraArgs = {
 
 const INVALID_ACCESS_TOKEN = 'Given access token is expired or invalid';
 
+// TODO Use throughout application
+export interface AppError extends Omit<AxiosError, 'response'> {
+  readonly response: AxiosResponse<string>;
+}
+
 export const responseErrorInterceptor = async (
   error: AxiosError,
 ): Promise<AxiosResponse> => {

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -47,7 +47,6 @@ export const refresh = (
   refreshToken: string,
 ): UserAuthenticationThunkAction<void> => {
   return (dispatch, getState, { authClient }): Promise<void> => {
-    dispatch(authenticateUser.loading());
     return authClient
       .refresh(refreshToken)
       .then((refreshTokenResponse: RefreshTokenResponse) => {

--- a/src/auth/test/authClient.test.ts
+++ b/src/auth/test/authClient.test.ts
@@ -1,9 +1,7 @@
-import { RefreshTokenResponse, TokenPayload } from '../ducks/types';
+import { RefreshTokenResponse } from '../ducks/types';
 import AuthClient, { API_ROUTE } from '../authClient';
 import nock from 'nock';
-import { mockTokenResponse } from '../../App.test';
-
-const BASE_URL = 'http://localhost';
+import { BASE_URL, mockTokenResponse } from '../../App.test';
 
 describe('Authentication Client Tests', () => {
   describe('Login', () => {

--- a/src/auth/test/authClient.test.ts
+++ b/src/auth/test/authClient.test.ts
@@ -1,25 +1,29 @@
 import { RefreshTokenResponse } from '../ducks/types';
 import AuthClient, { API_ROUTE } from '../authClient';
 import nock from 'nock';
-import { BASE_URL, mockTokenResponse } from '../../App.test';
+import { BASE_URL, invalidExp, mockTokenResponse } from '../../App.test';
 
 describe('Authentication Client Tests', () => {
   describe('Login', () => {
     it('makes the right request', async () => {
-      nock(BASE_URL).post(API_ROUTE.LOGIN).reply(200, mockTokenResponse);
+      nock(BASE_URL)
+        .post(API_ROUTE.LOGIN)
+        .reply(200, mockTokenResponse(invalidExp));
 
       const result = await AuthClient.login({
         email: 'jackblanc',
         password: 'password',
       });
 
-      expect(result).toEqual(mockTokenResponse);
+      expect(result).toEqual(mockTokenResponse(invalidExp));
     });
   });
 
   describe('Sign Up', () => {
     it('makes the right request', async () => {
-      nock(BASE_URL).post(API_ROUTE.SIGNUP).reply(200, mockTokenResponse);
+      nock(BASE_URL)
+        .post(API_ROUTE.SIGNUP)
+        .reply(200, mockTokenResponse(invalidExp));
 
       const result = await AuthClient.signup({
         password: 'password',
@@ -29,7 +33,7 @@ describe('Authentication Client Tests', () => {
         email: 'jblanc222@gmail.com',
       });
 
-      expect(result).toEqual(mockTokenResponse);
+      expect(result).toEqual(mockTokenResponse(invalidExp));
     });
   });
 

--- a/src/auth/test/axios.test.ts
+++ b/src/auth/test/axios.test.ts
@@ -1,0 +1,135 @@
+import {
+  accessToken,
+  BASE_URL,
+  invalidExp,
+  mockExpiredToken,
+  mockTokenResponse,
+  mockUserDataResponse,
+  validExp,
+} from '../../App.test';
+import { AdminApiClientRoutes } from '../../api/protectedApiClient';
+import { AxiosError } from 'axios';
+import authClient from '../authClient';
+import { responseErrorInterceptor } from '../axios';
+import store, { C4CState } from '../../store';
+import { AsyncRequestCompleted } from '../../utils/asyncRequest';
+import { generateState } from './thunks.test';
+import nock from 'nock';
+
+// a mock partial state with a valid refresh token
+const mockValidAuthState: Partial<C4CState> = {
+  authenticationState: {
+    tokens: AsyncRequestCompleted(mockTokenResponse(validExp)),
+    userData: AsyncRequestCompleted(mockUserDataResponse),
+  },
+};
+
+// a mock partial state with an invalid refresh token
+const mockInvalidAuthState: Partial<C4CState> = {
+  authenticationState: {
+    tokens: AsyncRequestCompleted(mockTokenResponse(invalidExp)),
+    userData: AsyncRequestCompleted(mockUserDataResponse),
+  },
+};
+
+// prepare to mock the store
+jest.mock('../../store');
+
+// prepare to mock authClient
+jest.mock('../authClient');
+
+describe('Axios Non-Refresh Tests', () => {
+  describe('responseErrorInterceptor', () => {
+    it('refreshes if the refresh token is not expired', async () => {
+      // mock unauthorized, refreshable state
+      store.getState = () => generateState(mockValidAuthState);
+
+      // mock successful refresh
+      const mockRefresh = jest.fn();
+      authClient.refresh = mockRefresh;
+      mockRefresh.mockResolvedValue({
+        freshAccessToken: accessToken,
+      });
+
+      // nock a successful request
+      const adoptionReportResponse = [
+        {
+          siteId: 0,
+          address: 'address',
+          name: 'A Doe',
+          email: 'adoe@email.com',
+          dateAdopted: '01-01-2021',
+          activityCount: 1,
+          neighborhood: 'South End',
+        },
+      ];
+      nock(BASE_URL)
+        .get(AdminApiClientRoutes.GET_ADOPTION_REPORT)
+        .reply(200, adoptionReportResponse);
+
+      const result = await responseErrorInterceptor(mockExpiredToken);
+
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+      expect(result.data).toEqual(adoptionReportResponse);
+    });
+
+    it('logs out if refresh token is expired and propagates error', async () => {
+      // mock unauthorized, un-refreshable state
+      store.getState = () => generateState(mockInvalidAuthState);
+
+      // mock logout and refresh
+      const mockLogout = jest.fn();
+      authClient.logout = mockLogout;
+      mockLogout.mockResolvedValue({});
+      authClient.refresh = jest.fn();
+
+      responseErrorInterceptor(mockExpiredToken)
+        .then(() => {
+          fail('Did not propagate error');
+        })
+        .catch((err) => {
+          expect(authClient.logout).toHaveBeenCalledTimes(1);
+          expect(err).toEqual(mockExpiredToken);
+        });
+    });
+
+    it('propagates error if not an expired token error and does not logout or refresh', async () => {
+      // mock logout and refresh
+      authClient.logout = jest.fn();
+      authClient.refresh = jest.fn();
+
+      // a bad request error (not 401)
+      const mockBadRequest: AxiosError = {
+        code: '',
+        config: {
+          url: AdminApiClientRoutes.GET_ADOPTION_REPORT,
+          baseURL: BASE_URL,
+        },
+        isAxiosError: false,
+        message: '',
+        name: '',
+        request: undefined,
+        response: {
+          status: 400,
+          data: 'Bad request',
+          statusText: '',
+          config: {},
+          headers: undefined,
+        },
+        toJSON: () => {
+          return mockExpiredToken;
+        },
+      };
+
+      responseErrorInterceptor(mockBadRequest)
+        .then(() => {
+          fail('Did not propagate error');
+        })
+        .catch((err) => {
+          expect(authClient.logout).toHaveBeenCalledTimes(0);
+          expect(authClient.refresh).toHaveBeenCalledTimes(0);
+          expect(err).toEqual(mockBadRequest);
+        });
+    });
+  });
+});

--- a/src/auth/test/axios.test.ts
+++ b/src/auth/test/axios.test.ts
@@ -32,9 +32,6 @@ const mockInvalidAuthState: Partial<C4CState> = {
   },
 };
 
-// prepare to mock the store
-jest.mock('../../store');
-
 // prepare to mock authClient
 jest.mock('../authClient');
 

--- a/src/auth/test/reducers.test.ts
+++ b/src/auth/test/reducers.test.ts
@@ -6,15 +6,21 @@ import {
   UserData,
 } from '../ducks/types';
 import { AsyncRequestCompleted } from '../../utils/asyncRequest';
-import { mockTokenResponse, mockUserDataResponse } from '../../App.test';
+import {
+  invalidExp,
+  mockTokenResponse,
+  mockUserDataResponse,
+} from '../../App.test';
 
 describe('User Authentication Reducers', () => {
   describe('Token Payload', () => {
     it('Updates state correctly when a user authenticates successfully', () => {
-      const action = authenticateUser.loaded(mockTokenResponse);
+      const action = authenticateUser.loaded(mockTokenResponse(invalidExp));
       const expectedNextState: UserAuthenticationReducerState = {
         ...initialUserState,
-        tokens: AsyncRequestCompleted<TokenPayload, void>(mockTokenResponse),
+        tokens: AsyncRequestCompleted<TokenPayload, void>(
+          mockTokenResponse(invalidExp),
+        ),
       };
       expect(reducers(initialUserState, action)).toEqual(expectedNextState);
     });

--- a/src/auth/test/selectors.test.ts
+++ b/src/auth/test/selectors.test.ts
@@ -12,7 +12,11 @@ import {
   getUsername,
   isLoggedIn,
 } from '../ducks/selectors';
-import { mockTokenResponse, mockUserDataResponse } from '../../App.test';
+import {
+  invalidExp,
+  mockTokenResponse,
+  mockUserDataResponse,
+} from '../../App.test';
 
 describe('User Authentication Selectors', () => {
   describe('getPrivilegeLevel', () => {
@@ -73,7 +77,7 @@ describe('User Authentication Selectors', () => {
       const tokens: AsyncRequest<TokenPayload, any> = AsyncRequestCompleted<
         TokenPayload,
         any
-      >(mockTokenResponse);
+      >(mockTokenResponse(invalidExp));
 
       expect(isLoggedIn(tokens)).toEqual(true);
     });

--- a/src/auth/test/thunks.test.ts
+++ b/src/auth/test/thunks.test.ts
@@ -8,9 +8,12 @@ import protectedApiClient, {
 } from '../../api/protectedApiClient';
 import apiClient from '../../api/apiClient';
 import nock from 'nock';
-import { mockTokenResponse, mockUserDataResponse } from '../../App.test';
-
-const BASE_URL = 'http://localhost';
+import {
+  BASE_URL,
+  invalidExp,
+  mockTokenResponse,
+  mockUserDataResponse,
+} from '../../App.test';
 
 export const generateState = (partialState: Partial<C4CState>): C4CState => ({
   ...initialStoreState,
@@ -24,7 +27,7 @@ describe('User Authentication Thunks', () => {
       const mockDispatch = jest.fn();
       const mockLogin = jest.fn();
       const mockOnError = jest.fn();
-      mockLogin.mockResolvedValue(mockTokenResponse);
+      mockLogin.mockResolvedValue(mockTokenResponse(invalidExp));
       nock(BASE_URL)
         .get(ProtectedApiClientRoutes.GET_USER_DATA)
         .reply(200, mockUserDataResponse);
@@ -49,7 +52,7 @@ describe('User Authentication Thunks', () => {
       expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(mockDispatch).toHaveBeenNthCalledWith(
         4,
-        authenticateUser.loaded(mockTokenResponse),
+        authenticateUser.loaded(mockTokenResponse(invalidExp)),
       );
       expect(mockDispatch).toHaveBeenNthCalledWith(
         3,
@@ -101,7 +104,7 @@ describe('User Authentication Thunks', () => {
       const mockDispatch = jest.fn();
       const mockLogin = jest.fn();
       const mockOnError = jest.fn();
-      mockLogin.mockResolvedValue(mockTokenResponse);
+      mockLogin.mockResolvedValue(mockTokenResponse(invalidExp));
       const mockUserDataError = 'mock fail';
       nock(BASE_URL)
         .get(ProtectedApiClientRoutes.GET_USER_DATA)
@@ -127,7 +130,7 @@ describe('User Authentication Thunks', () => {
       expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(mockDispatch).toHaveBeenNthCalledWith(
         4,
-        authenticateUser.loaded(mockTokenResponse),
+        authenticateUser.loaded(mockTokenResponse(invalidExp)),
       );
       expect(mockDispatch).toHaveBeenNthCalledWith(
         3,
@@ -162,9 +165,9 @@ describe('User Authentication Thunks', () => {
 
       await refresh(mockRefreshToken)(mockDispatch, getState, mockExtraArgs);
 
-      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenNthCalledWith(
-        2,
+        1,
         authenticateUser.loaded({
           accessToken: mockRefreshTokenResponse.freshAccessToken,
           refreshToken: mockRefreshToken,
@@ -194,9 +197,9 @@ describe('User Authentication Thunks', () => {
 
       await refresh(mockRefreshToken)(mockDispatch, getState, mockExtraArgs);
 
-      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenNthCalledWith(
-        2,
+        1,
         authenticateUser.failed(mockAPIError.response.data),
       );
       expect(mockRefresh).toBeCalledTimes(1);
@@ -208,7 +211,7 @@ describe('User Authentication Thunks', () => {
       const getState = () => generateState({});
       const mockDispatch = jest.fn();
       const mockSignup = jest.fn();
-      mockSignup.mockResolvedValue(mockTokenResponse);
+      mockSignup.mockResolvedValue(mockTokenResponse(invalidExp));
       const mockExtraArgs: ThunkExtraArgs = {
         authClient: {
           ...authClient,
@@ -236,7 +239,7 @@ describe('User Authentication Thunks', () => {
       expect(mockDispatch).toHaveBeenCalledTimes(4);
       expect(mockDispatch).toHaveBeenNthCalledWith(
         4,
-        authenticateUser.loaded(mockTokenResponse),
+        authenticateUser.loaded(mockTokenResponse(invalidExp)),
       );
       expect(mockDispatch).toHaveBeenNthCalledWith(
         3,

--- a/src/containers/login/test/login.test.tsx
+++ b/src/containers/login/test/login.test.tsx
@@ -12,7 +12,11 @@ import { Store } from 'redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { Routes } from '../../../App';
-import { mockTokenResponse, mockUserDataResponse } from '../../../App.test';
+import {
+  invalidExp,
+  mockTokenResponse,
+  mockUserDataResponse,
+} from '../../../App.test';
 
 // window.matchMedia is invoked when rendering the Login page, but is not implemented in JSDOM, so we mock it here
 // see more: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
@@ -51,7 +55,7 @@ describe('Login', () => {
     // create a mock state where the user is logged in
     const mockAuthState: Partial<C4CState> = {
       authenticationState: {
-        tokens: AsyncRequestCompleted(mockTokenResponse),
+        tokens: AsyncRequestCompleted(mockTokenResponse(invalidExp)),
         userData: AsyncRequestCompleted(mockUserDataResponse),
       },
     };

--- a/src/containers/reports/index.tsx
+++ b/src/containers/reports/index.tsx
@@ -31,17 +31,20 @@ const Reports: React.FC = () => {
 
   useEffect(() => {
     ProtectedApiClient.getAdoptionReport()
-      .then((res: AdoptionReport) => setAdoptionReport(res))
+      .then((adoptionRes: AdoptionReport) => {
+        setAdoptionReport(adoptionRes);
+        ProtectedApiClient.getStewardshipReport()
+          .then((stewardshipRes: StewardshipReport) =>
+            setStewardshipReport(stewardshipRes),
+          )
+          .catch((err) =>
+            message.error(
+              `Could not get stewardship report: ${getErrorMessage(err)}`,
+            ),
+          );
+      })
       .catch((err) =>
         message.error(`Could not get adoption report: ${getErrorMessage(err)}`),
-      );
-
-    ProtectedApiClient.getStewardshipReport()
-      .then((res: StewardshipReport) => setStewardshipReport(res))
-      .catch((err) =>
-        message.error(
-          `Could not get stewardship report: ${getErrorMessage(err)}`,
-        ),
       );
   }, []);
 

--- a/src/utils/stringFormat.tsx
+++ b/src/utils/stringFormat.tsx
@@ -1,5 +1,6 @@
 import { Entry, MainSiteEntryOrder } from '../containers/treePage/ducks/types';
 import { NEIGHBORHOOD_IDS } from '../assets/content';
+import { AppError } from '../auth/axios';
 
 /**
  * Converts the given dollar amount to a formatted string
@@ -124,6 +125,6 @@ export function getNeighborhoodName(id: number): string {
  * Returns the error message of the given error.
  * @param err the error
  */
-export function getErrorMessage(err: any): string {
-  return `${err?.response?.data || 'Error encountered'}`;
+export function getErrorMessage(err: AppError): string {
+  return err.response.data;
 }

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -11,6 +11,7 @@ import { getDateString } from '../stringFormat';
 import { shortHand } from '../stringFormat';
 import { SHORT_HAND_NAMES } from '../../assets/content';
 import { Entry } from '../../containers/treePage/ducks/types';
+import { AppError } from '../../auth/axios';
 
 test('getMoneyString tests', () => {
   expect(getMoneyString(100000)).toBe('$100,000');
@@ -136,15 +137,21 @@ test('getNeighborhoodName tests', () => {
 });
 
 test('getErrorMessage', () => {
-  const exampleError = { response: { data: 'uh oh', extra: 'data' } };
-  const exampleErrorWithoutData = { response: { extra: 'data' } };
-  const exampleErrorWithoutResponse = {
-    data: { data: 'uh oh', extra: 'data' },
+  const exampleError: AppError = {
+    config: {},
+    isAxiosError: false,
+    message: '',
+    name: '',
+    response: {
+      data: 'uh oh',
+      status: 400,
+      statusText: 'bad',
+      headers: [],
+      config: {},
+    },
+    toJSON: () => {
+      return exampleError;
+    },
   };
   expect(getErrorMessage(exampleError)).toEqual('uh oh');
-  expect(getErrorMessage(exampleErrorWithoutData)).toEqual('Error encountered');
-  expect(getErrorMessage(exampleErrorWithoutResponse)).toEqual(
-    'Error encountered',
-  );
-  expect(getErrorMessage(undefined)).toEqual('Error encountered');
 });


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/29a81x7)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Doesn't show auth error after successful refresh and properly logs out user if refresh token is expired. Adds an error type to make handling errors easier.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Essentially made some fixes to responseErrorInterceptor - will leave comments.

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
- Wrote tests for the error response interceptor and ensured they passed
- Manually checked that refresh/force logout worked (you can make this easier to test by changing `expiration_ms_refresh` and `expiration_ms_access` in the backend)