### PR TITLE
Set font to Montserrat

### DIFF
--- a/antd.customize.less
+++ b/antd.customize.less
@@ -12,7 +12,7 @@
 @component-background: @white;
 @primary-5: @white; // text and border color for active buttons
 @item-active-bg: @white;
-@font-family: Circular, 'Circular', sans-serif;
+@font-family: Montserrat, 'Montserrat', sans-serif;
 @heading-color: @mid-green;
 @heading-color-secondary: @dark-green;
 @text-color: @black;

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,700&display=swap"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -28,12 +28,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-
-    <!-- Loading IBM Plex Sans from CDN directly in HTML as <link> tag -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&display=swap"
-      rel="stylesheet"
-    />
 
     <title>Speak for the Trees</title>
   </head>

--- a/src/components/treePopup/index.tsx
+++ b/src/components/treePopup/index.tsx
@@ -16,6 +16,8 @@ import { CITY_PLANTING_REQUEST_LINK } from '../../assets/content';
 
 const PopupContainer = styled.div`
   position: absolute;
+  /* override google maps styling, which uses Roboto */
+  font-family: Montserrat;
 `;
 
 const PopupAnchor = styled.div`


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/1geybt7)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Aesthetic change

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Imports Montserrat from Goole Fonts and sets AntD theme's font-family to Montserrat.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![image](https://user-images.githubusercontent.com/22990100/164808865-be9e3d75-2d3e-4547-97e7-7035aead0981.png)
![image](https://user-images.githubusercontent.com/22990100/164809024-7ed1fc3b-b7c9-4875-be6a-74e7d877ac08.png)
![image](https://user-images.githubusercontent.com/22990100/164809177-6cd6be29-9508-440d-b447-9a79cfceb537.png)
![image](https://user-images.githubusercontent.com/22990100/164809302-96aabede-86b2-4019-afc3-d9b0f7e0a345.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually checked the font updated and looks good on each page.