### PR TITLE
Mobile Map Visual Updates

### DIFF
--- a/src/components/adoptionDirections/index.tsx
+++ b/src/components/adoptionDirections/index.tsx
@@ -41,36 +41,36 @@ const AdoptionDirections: React.FC<AdoptionDirectionsProps> = ({ mobile }) => {
 
   return (
     <div>
-        {mobile ? (
-          <MobileTitle>{ADOPTION_DIRECTIONS_HEADER}</MobileTitle>
-        ) : (
-          <Typography.Title level={3}>
-            {ADOPTION_DIRECTIONS_HEADER}
-          </Typography.Title>
-        )}
+      {mobile ? (
+        <MobileTitle>{ADOPTION_DIRECTIONS_HEADER}</MobileTitle>
+      ) : (
+        <Typography.Title level={3}>
+          {ADOPTION_DIRECTIONS_HEADER}
+        </Typography.Title>
+      )}
 
-        <FlexibleParagraph fontSize={fontSize}>
-          <Row>
-            <NumberCol>
-              <Typography.Text strong>1.</Typography.Text>
-            </NumberCol>
-            <DirectionCol>{FIND_DIRECTION}</DirectionCol>
-          </Row>
+      <FlexibleParagraph fontSize={fontSize}>
+        <Row>
+          <NumberCol>
+            <Typography.Text strong>1.</Typography.Text>
+          </NumberCol>
+          <DirectionCol>{FIND_DIRECTION}</DirectionCol>
+        </Row>
 
-          <Row>
-            <NumberCol>
-              <Typography.Text strong>2.</Typography.Text>
-            </NumberCol>
-            <DirectionCol>{ICONS_DIRECTION}</DirectionCol>
-          </Row>
+        <Row>
+          <NumberCol>
+            <Typography.Text strong>2.</Typography.Text>
+          </NumberCol>
+          <DirectionCol>{ICONS_DIRECTION}</DirectionCol>
+        </Row>
 
-          <Row>
-            <NumberCol>
-              <Typography.Text strong>3.</Typography.Text>
-            </NumberCol>
-            <DirectionCol>{REDIRECTED_DIRECTION}</DirectionCol>
-          </Row>
-        </FlexibleParagraph>
+        <Row>
+          <NumberCol>
+            <Typography.Text strong>3.</Typography.Text>
+          </NumberCol>
+          <DirectionCol>{REDIRECTED_DIRECTION}</DirectionCol>
+        </Row>
+      </FlexibleParagraph>
     </div>
   );
 };

--- a/src/components/adoptionDirections/index.tsx
+++ b/src/components/adoptionDirections/index.tsx
@@ -8,6 +8,7 @@ import {
   REDIRECTED_DIRECTION,
 } from '../../assets/content';
 import { MID_GREEN } from '../../utils/colors';
+import { DESKTOP_FONT_SIZE, MOBILE_FONT_SIZE } from '../themedComponents';
 
 const MobileTitle = styled(Typography.Paragraph)`
   color: ${MID_GREEN};
@@ -37,7 +38,7 @@ interface AdoptionDirectionsProps {
 }
 
 const AdoptionDirections: React.FC<AdoptionDirectionsProps> = ({ mobile }) => {
-  const fontSize = `${mobile ? '15px' : '12px'}`;
+  const fontSize = `${mobile ? MOBILE_FONT_SIZE : DESKTOP_FONT_SIZE}`;
 
   return (
     <div>

--- a/src/components/adoptionDirections/index.tsx
+++ b/src/components/adoptionDirections/index.tsx
@@ -37,11 +37,10 @@ interface AdoptionDirectionsProps {
 }
 
 const AdoptionDirections: React.FC<AdoptionDirectionsProps> = ({ mobile }) => {
-  const fontSize = `${mobile ? '10px' : '12px'}`;
+  const fontSize = `${mobile ? '15px' : '12px'}`;
 
   return (
-    <>
-      <>
+    <div>
         {mobile ? (
           <MobileTitle>{ADOPTION_DIRECTIONS_HEADER}</MobileTitle>
         ) : (
@@ -72,8 +71,7 @@ const AdoptionDirections: React.FC<AdoptionDirectionsProps> = ({ mobile }) => {
             <DirectionCol>{REDIRECTED_DIRECTION}</DirectionCol>
           </Row>
         </FlexibleParagraph>
-      </>
-    </>
+    </div>
   );
 };
 

--- a/src/components/mapComponents/constants.tsx
+++ b/src/components/mapComponents/constants.tsx
@@ -27,7 +27,7 @@ export const BOSTON_BOUNDS = {
 export const STREET_ZOOM = 19;
 
 export const MOBILE_SLIDE_HEIGHT = 60;
-export const DESKTOP_SLIDE_HEIGHT = 60;
+export const DESKTOP_SLIDE_HEIGHT = 70;
 
 // Three years before the current date
 export const YOUNG_TREE_DATE = new Date().setFullYear(

--- a/src/components/mapComponents/constants.tsx
+++ b/src/components/mapComponents/constants.tsx
@@ -26,6 +26,9 @@ export const BOSTON_BOUNDS = {
 
 export const STREET_ZOOM = 19;
 
+export const MOBILE_SLIDE_HEIGHT = 60;
+export const DESKTOP_SLIDE_HEIGHT = 60;
+
 // Three years before the current date
 export const YOUNG_TREE_DATE = new Date().setFullYear(
   new Date().getFullYear() - 3,

--- a/src/components/mapComponents/mapLegend/index.tsx
+++ b/src/components/mapComponents/mapLegend/index.tsx
@@ -17,7 +17,11 @@ import youngTreeIcon from '../../../assets/images/siteIcons/youngLarge.png';
 import openSiteIcon from '../../../assets/images/siteIcons/openLarge.png';
 import { MAP_GREEN, MAP_RED, MAP_YELLOW, RED } from '../../../utils/colors';
 import { MapViews } from '../ducks/types';
-import { InlineImage } from '../../themedComponents';
+import {
+  DESKTOP_FONT_SIZE,
+  InlineImage,
+  MOBILE_FONT_SIZE,
+} from '../../themedComponents';
 
 const MapLegendContainer = styled.div`
   margin-bottom: 5px;
@@ -69,7 +73,7 @@ interface MapLegendProps {
 const MapLegend: React.FC<MapLegendProps> = ({ view, mobile, canHide }) => {
   const [showLegend, setShowLegend] = useState(true);
 
-  const fontSize = `${mobile ? '15px' : '12px'}`;
+  const fontSize = `${mobile ? MOBILE_FONT_SIZE : DESKTOP_FONT_SIZE}`;
 
   const toggleShowLegend = () => {
     setShowLegend((prevState) => !prevState);

--- a/src/components/mapComponents/mapLegend/index.tsx
+++ b/src/components/mapComponents/mapLegend/index.tsx
@@ -69,7 +69,7 @@ interface MapLegendProps {
 const MapLegend: React.FC<MapLegendProps> = ({ view, mobile, canHide }) => {
   const [showLegend, setShowLegend] = useState(true);
 
-  const fontSize = `${mobile ? '10px' : '12px'}`;
+  const fontSize = `${mobile ? '15px' : '12px'}`;
 
   const toggleShowLegend = () => {
     setShowLegend((prevState) => !prevState);

--- a/src/components/mapComponents/mapPageComponents/mobileLandingBar/index.tsx
+++ b/src/components/mapComponents/mapPageComponents/mobileLandingBar/index.tsx
@@ -10,22 +10,20 @@ import {
   WHITE,
   BLACK,
 } from '../../../../utils/colors';
+import { Flex } from '../../../themedComponents';
 
 const MobileBarContentContainer = styled.div`
   display: block;
-  height: 35vh;
+  padding-bottom: 10px;
 `;
 
 const TitleButtonsContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: 90vw;
   margin: 0px -30px;
 `;
 
 const TitleContainer = styled.div`
-  display: inline-block;
+  display: block;
   min-width: 200px;
   max-width: 95%;
 `;
@@ -38,12 +36,7 @@ const MobileTitle = styled(Typography.Paragraph)`
 `;
 
 const MobileParagraph = styled(Typography.Paragraph)`
-  font-size: 9px;
-`;
-
-const ButtonsContainer = styled.div`
-  display: inline-block;
-  margin-left: 30px;
+  font-size: 15px;
 `;
 
 const LoginButton = styled(Button)`
@@ -57,14 +50,19 @@ const LoginButton = styled(Button)`
 const SignUpButton = styled(Button)`
   width: 100px;
   height: 50px;
-  margin-top: 15px;
   background-color: ${LIGHT_GREEN};
   border-color: ${LIGHT_GREEN};
 `;
 
 const LandingStatsContainer = styled.div`
-  width: 90vw;
-  margin: 0vh -30px;
+  width: 100%;
+  display: flex;
+  row-gap: 30px;
+  flex-wrap: wrap;
+`;
+
+const StyledFlex = styled(Flex)`
+  margin-bottom: 15px;
 `;
 
 interface MobileLandingBarProps {
@@ -82,7 +80,7 @@ const MobileLandingBar: React.FC<MobileLandingBarProps> = ({
   const history = useHistory();
 
   return (
-    <>
+    <Flex>
       <MobileBarContentContainer>
         <TitleButtonsContainer>
           <TitleContainer>
@@ -90,7 +88,7 @@ const MobileLandingBar: React.FC<MobileLandingBarProps> = ({
             <MobileParagraph>{barDescription}</MobileParagraph>
           </TitleContainer>
           {!isLoggedIn && (
-            <ButtonsContainer>
+            <StyledFlex justifyContent={'center'}>
               <div>
                 <LoginButton
                   type="primary"
@@ -111,12 +109,12 @@ const MobileLandingBar: React.FC<MobileLandingBarProps> = ({
                   Sign Up
                 </SignUpButton>
               </div>
-            </ButtonsContainer>
+            </StyledFlex>
           )}
         </TitleButtonsContainer>
         <LandingStatsContainer>{children}</LandingStatsContainer>
       </MobileBarContentContainer>
-    </>
+    </Flex>
   );
 };
 

--- a/src/components/mapComponents/mapPageComponents/siteLegend/index.tsx
+++ b/src/components/mapComponents/mapPageComponents/siteLegend/index.tsx
@@ -28,7 +28,7 @@ interface SiteLegendProps {
 const SiteLegend: React.FC<SiteLegendProps> = ({ onCheck }) => {
   return (
     <LegendContainer>
-      <SlideDown defaultOpen={true} fullSlide={true}>
+      <SlideDown defaultOpen={true} slideHeight={70}>
         <MapLegend view={MapViews.TREES} mobile={false} />
         <Typography.Text strong>Show</Typography.Text>
         <StyledCheckbox

--- a/src/components/mapComponents/mapPageComponents/siteLegend/index.tsx
+++ b/src/components/mapComponents/mapPageComponents/siteLegend/index.tsx
@@ -6,7 +6,11 @@ import { MapViews } from '../../ducks/types';
 import { CheckboxValueType } from 'antd/es/checkbox/Group';
 import SlideDown from '../../../slideDown';
 import MapLegend from '../../mapLegend';
-import { ALL_SITES_VISIBLE, SITE_OPTIONS } from '../../constants';
+import {
+  ALL_SITES_VISIBLE,
+  DESKTOP_SLIDE_HEIGHT,
+  SITE_OPTIONS,
+} from '../../constants';
 
 const LegendContainer = styled.div`
   min-width: 300px;
@@ -28,7 +32,7 @@ interface SiteLegendProps {
 const SiteLegend: React.FC<SiteLegendProps> = ({ onCheck }) => {
   return (
     <LegendContainer>
-      <SlideDown defaultOpen={true} slideHeight={70}>
+      <SlideDown defaultOpen={true} slideHeight={DESKTOP_SLIDE_HEIGHT}>
         <MapLegend view={MapViews.TREES} mobile={false} />
         <Typography.Text strong>Show</Typography.Text>
         <StyledCheckbox

--- a/src/components/mapComponents/maps/mapWithPopup/index.tsx
+++ b/src/components/mapComponents/maps/mapWithPopup/index.tsx
@@ -7,11 +7,16 @@ import TreePopup, { BasicTreeInfo } from '../../../treePopup';
 import styled from 'styled-components';
 import { goToPlace } from '../../logic/view';
 import { InitMapData } from '../../ducks/types';
+import { BREAKPOINT_TABLET } from '../../../windowDimensions';
 
 const StyledSearch = styled(Input.Search)`
   width: 20vw;
   position: absolute;
   z-index: 2;
+
+  @media (max-width: ${BREAKPOINT_TABLET}px) {
+    width: 100vw;
+  }
 `;
 
 const MapDiv = styled.div`

--- a/src/components/mapComponents/maps/selectorMap/index.tsx
+++ b/src/components/mapComponents/maps/selectorMap/index.tsx
@@ -53,7 +53,7 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
 
     const mapLayersAndListeners = initSiteView(mapData, neighborhoods, sites);
 
-    return {
+    const setMapData: ReturnMapData = {
       map: mapData.map,
       zoom: mapData.zoom,
       privateStreetsLayer: mapLayersAndListeners.privateStreetsLayer,
@@ -63,6 +63,12 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
       zoomListener: mapLayersAndListeners.zoomListener,
       markersArray: mapData.markersArray,
     };
+
+    mapData.map.setOptions({
+      gestureHandling: 'greedy',
+    });
+
+    return setMapData;
   };
 
   return (

--- a/src/components/mapComponents/maps/selectorMap/index.tsx
+++ b/src/components/mapComponents/maps/selectorMap/index.tsx
@@ -65,6 +65,8 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
     };
 
     mapData.map.setOptions({
+      // Configures the map to react to all user touch input,
+      // allowing one finger to be used to control map movement rather than page scrolling
       gestureHandling: 'greedy',
     });
 

--- a/src/components/mapComponents/maps/treeMap/index.tsx
+++ b/src/components/mapComponents/maps/treeMap/index.tsx
@@ -63,6 +63,7 @@ const TreeMap: React.FC<TreeMapProps> = ({
 
     mapData.map.setOptions({
       styles: LIGHT_MAP_STYLES,
+      gestureHandling: 'greedy',
     });
 
     return setMapData;

--- a/src/components/mapComponents/maps/treeMap/index.tsx
+++ b/src/components/mapComponents/maps/treeMap/index.tsx
@@ -63,6 +63,8 @@ const TreeMap: React.FC<TreeMapProps> = ({
 
     mapData.map.setOptions({
       styles: LIGHT_MAP_STYLES,
+      // Configures the map to react to all user touch input,
+      // allowing one finger to be used to control map movement rather than page scrolling
       gestureHandling: 'greedy',
     });
 

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Routes } from '../../App';
+import {Routes} from '../../App';
 import styled from 'styled-components';
-import { Col, Row } from 'antd';
-import useWindowDimensions, { WindowTypes } from '../windowDimensions';
+import {Col, Row} from 'antd';
+import useWindowDimensions, {WindowTypes} from '../windowDimensions';
 import MobileNavBar from './mobileNavBar';
-import { BACKGROUND_GREY, MID_GREEN } from '../../utils/colors';
+import {BACKGROUND_GREY, MID_GREEN} from '../../utils/colors';
 import sfttLogo from '../../assets/images/sfttNameLogo.png';
 import bostonLogo from '../../assets/images/bostonParksLogo.png';
 import c4cLogo from '../../assets/images/c4cTextLogo.png';
-import { LinkButton } from '../linkButton';
+import {LinkButton} from '../linkButton';
 import NavExtra from './navExtra';
 
 const NavContainer = styled.div`
@@ -68,7 +68,7 @@ interface NavBarProps {
 const NavBar: React.FC<NavBarProps> = ({ userName, isAdmin, onLogout }) => {
   const { windowType } = useWindowDimensions();
 
-  if (windowType === WindowTypes.Mobile) {
+  if (windowType === WindowTypes.Mobile || windowType === WindowTypes.Tablet) {
     return (
       <MobileNavBar
         isLoggedIn={userName !== undefined}

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import {Routes} from '../../App';
+import { Routes } from '../../App';
 import styled from 'styled-components';
-import {Col, Row} from 'antd';
-import useWindowDimensions, {WindowTypes} from '../windowDimensions';
+import { Col, Row } from 'antd';
+import useWindowDimensions, { WindowTypes } from '../windowDimensions';
 import MobileNavBar from './mobileNavBar';
-import {BACKGROUND_GREY, MID_GREEN} from '../../utils/colors';
+import { BACKGROUND_GREY, MID_GREEN } from '../../utils/colors';
 import sfttLogo from '../../assets/images/sfttNameLogo.png';
 import bostonLogo from '../../assets/images/bostonParksLogo.png';
 import c4cLogo from '../../assets/images/c4cTextLogo.png';
-import {LinkButton} from '../linkButton';
+import { LinkButton } from '../linkButton';
 import NavExtra from './navExtra';
 
 const NavContainer = styled.div`

--- a/src/components/navBar/test/navBar.test.tsx
+++ b/src/components/navBar/test/navBar.test.tsx
@@ -20,6 +20,9 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+// Mock window size to test Desktop Nav Bar
+Object.assign(window, { innerWidth: 1400 });
+
 describe('NavBar', () => {
   it('shows proper content when logged out', () => {
     const mockLogout = jest.fn();

--- a/src/components/slideDown/index.tsx
+++ b/src/components/slideDown/index.tsx
@@ -42,12 +42,12 @@ const CaretUpStyled = styled(CaretUpOutlined)`
 
 interface SlideDownProps {
   readonly defaultOpen?: boolean;
-  readonly fullSlide?: boolean;
+  readonly slideHeight?: number;
 }
 
 const SlideDown: React.FC<SlideDownProps> = ({
   defaultOpen,
-  fullSlide,
+  slideHeight,
   children,
 }) => {
   const [setActive, setActiveState] = useState<boolean>(defaultOpen || false);
@@ -55,8 +55,6 @@ const SlideDown: React.FC<SlideDownProps> = ({
   function handleClick() {
     setActiveState((prevState) => !prevState);
   }
-
-  const slideHeight = fullSlide ? 80 : 40;
 
   return (
     <SlideDownSectionDiv>
@@ -66,7 +64,7 @@ const SlideDown: React.FC<SlideDownProps> = ({
       <SlideDownContentDiv
         ref={content}
         setActive={setActive}
-        slideHeight={slideHeight}
+        slideHeight={slideHeight || 40}
       >
         <SlideDownTextDiv>{children}</SlideDownTextDiv>
       </SlideDownContentDiv>

--- a/src/components/themedComponents/index.tsx
+++ b/src/components/themedComponents/index.tsx
@@ -11,6 +11,9 @@ import {
 import { LinkButton } from '../linkButton';
 import { BREAKPOINT_TABLET } from '../windowDimensions';
 
+export const MOBILE_FONT_SIZE = '15px';
+export const DESKTOP_FONT_SIZE = '12px';
+
 export const PaddedPageContainer = styled.div`
   padding: 5vh 5vw;
 `;

--- a/src/containers/landing/index.tsx
+++ b/src/containers/landing/index.tsx
@@ -20,9 +20,12 @@ import AdoptionDirections from '../../components/adoptionDirections';
 import MapLegend from '../../components/mapComponents/mapLegend';
 import { Routes } from '../../App';
 import TreeMapDisplay from '../../components/mapComponents/mapDisplays/treeMapDisplay';
+import SlideDown from '../../components/slideDown';
 
 const PaddedContent = styled.div`
-  padding: 24px 50px;
+  padding: 15px 0px;
+  width: 80%;
+  margin: auto;
 `;
 
 interface LandingProps {
@@ -56,6 +59,7 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, sites }) => {
       {(() => {
         switch (windowType) {
           case WindowTypes.Mobile:
+          case WindowTypes.Tablet:
             return (
               <MobileMapPage
                 mapContent={
@@ -67,23 +71,24 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, sites }) => {
                 }
                 returnTo={Routes.LANDING}
               >
-                <PaddedContent>
-                  <MobileLandingBar
-                    barHeader={LANDING_TITLE}
-                    barDescription={LANDING_BODY}
-                    isLoggedIn={loggedIn}
-                  >
-                    <MapLegend
-                      view={landingMapView}
-                      mobile={true}
-                      canHide={true}
-                    />
-                    <AdoptionDirections mobile={true} />
-                  </MobileLandingBar>
-                </PaddedContent>
+                <SlideDown defaultOpen={true} slideHeight={60}>
+                  <PaddedContent>
+                    <MobileLandingBar
+                      barHeader={LANDING_TITLE}
+                      barDescription={LANDING_BODY}
+                      isLoggedIn={loggedIn}
+                    >
+                      <MapLegend
+                        view={landingMapView}
+                        mobile={true}
+                        canHide={false}
+                      />
+                      <AdoptionDirections mobile={true} />
+                    </MobileLandingBar>
+                  </PaddedContent>
+                </SlideDown>
               </MobileMapPage>
             );
-          case WindowTypes.Tablet:
           case WindowTypes.NarrowDesktop:
           case WindowTypes.Desktop:
             return (

--- a/src/containers/landing/index.tsx
+++ b/src/containers/landing/index.tsx
@@ -21,6 +21,7 @@ import MapLegend from '../../components/mapComponents/mapLegend';
 import { Routes } from '../../App';
 import TreeMapDisplay from '../../components/mapComponents/mapDisplays/treeMapDisplay';
 import SlideDown from '../../components/slideDown';
+import { MOBILE_SLIDE_HEIGHT } from '../../components/mapComponents/constants';
 
 const PaddedContent = styled.div`
   padding: 15px 0px;
@@ -71,7 +72,7 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, sites }) => {
                 }
                 returnTo={Routes.LANDING}
               >
-                <SlideDown defaultOpen={true} slideHeight={60}>
+                <SlideDown defaultOpen={true} slideHeight={MOBILE_SLIDE_HEIGHT}>
                   <PaddedContent>
                     <MobileLandingBar
                       barHeader={LANDING_TITLE}

--- a/src/containers/myTrees/index.tsx
+++ b/src/containers/myTrees/index.tsx
@@ -82,7 +82,7 @@ const MyTrees: React.FC<MyTreesStateProps> = ({ neighborhoods, sites }) => {
                 }
                 returnTo={Routes.MY_TREES}
               >
-                <SlideDown defaultOpen fullSlide>
+                <SlideDown defaultOpen slideHeight={80}>
                   <TreeSidebar mySites={mySites} />
                 </SlideDown>
               </MobileMapPage>

--- a/src/containers/myTrees/index.tsx
+++ b/src/containers/myTrees/index.tsx
@@ -26,6 +26,7 @@ import {
 import { getMySites } from './ducks/selectors';
 import { Routes } from '../../App';
 import TreeMapDisplay from '../../components/mapComponents/mapDisplays/treeMapDisplay';
+import { MOBILE_SLIDE_HEIGHT } from '../../components/mapComponents/constants';
 
 interface MyTreesStateProps {
   readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
@@ -71,6 +72,7 @@ const MyTrees: React.FC<MyTreesStateProps> = ({ neighborhoods, sites }) => {
       {(() => {
         switch (windowType) {
           case WindowTypes.Mobile:
+          case WindowTypes.Tablet:
             return (
               <MobileMapPage
                 mapContent={
@@ -82,12 +84,11 @@ const MyTrees: React.FC<MyTreesStateProps> = ({ neighborhoods, sites }) => {
                 }
                 returnTo={Routes.MY_TREES}
               >
-                <SlideDown defaultOpen slideHeight={80}>
+                <SlideDown defaultOpen slideHeight={MOBILE_SLIDE_HEIGHT}>
                   <TreeSidebar mySites={mySites} />
                 </SlideDown>
               </MobileMapPage>
             );
-          case WindowTypes.Tablet:
           case WindowTypes.NarrowDesktop:
           case WindowTypes.Desktop:
             return (


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/27pkxm1)

Makes it easier to view and interact with maps, especially on mobile, allowing the use of one-finger map movement and reducing the obtrusiveness of overlayed map elements. The use of slide-downs allow for more of the map to be visible on mobile.

## This PR

- Changed map options for gestureHandling to "greedy" on applicable maps.

- Changed SlideDown to fit on screen properly and extended its use on mobile for a better user experience.

- Changed search bar size on mobile to allow for practical use.

- Changed tablet view to more closely align with mobile rather than desktop for maps. 

## Screenshots

### Desktop landing page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166068651-d9997597-d96a-4f43-92c9-82ad45a9651b.png" width="500" />
  <img src="https://user-images.githubusercontent.com/46767048/166069005-0e41647d-3727-4232-bbd8-31ad69ba1e25.png" width="500" /> 
</p>

### Desktop my-trees page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166069595-4475506e-ec5f-405a-850f-ce05ff15698a.png" width="500" />
  <img src="https://user-images.githubusercontent.com/46767048/166069611-5d6069cd-3ac6-4078-8007-28134397a548.png" width="500" /> 
</p>

### Tablet landing page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166069715-774a1603-3f22-43c9-b4c1-d3785f790c47.png" width="400" />
  <img src="https://user-images.githubusercontent.com/46767048/166069739-e054223d-8c47-47b7-b630-fe733752c26a.png" width="400" /> 
</p>

### Tablet my-trees page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166069827-eff094d5-4e47-4862-b6a7-0c01791c1761.png" width="400" />
  <img src="https://user-images.githubusercontent.com/46767048/166069842-11f506d2-f4b4-4886-8907-c45e47c93ddc.png" width="400" /> 
</p>

### Mobile landing page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166069984-1362e1b7-3e8e-4869-82f6-ad319f9d067a.png" width="400" />
  <img src="https://user-images.githubusercontent.com/46767048/166070013-6f0a52dd-a860-4a0c-8e13-7809d1d741bc.png" width="400" /> 
</p>

### Mobile my-trees page old vs new
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166070141-529f77e1-dcd3-47ec-a90a-90653d299fba.png" width="400" />
  <img src="https://user-images.githubusercontent.com/46767048/166070157-6cdd77ac-bdd5-48e3-b971-9673f7ee08c3.png" width="400" /> 
</p>

### Fixed Mobile map scrolling issue
<p float="left">
  <img src="https://user-images.githubusercontent.com/46767048/166069551-163c92c5-ff3d-49ab-8648-0c94ec2f5fcb.png" width="400" />
  <img src="https://user-images.githubusercontent.com/46767048/166069525-8edb77e5-744f-45c2-ae7b-f54e6c840508.png" width="400" / title="Yes I'm aware that a still image is not really evidence that it's fixed. Guess you'll just have to trust me. 😉"> 
</p>

## Verification Steps

Visually inspected changes to landing map, my trees page, and site maps on desktop, tablet, and mobile sizes, and interacted with the maps to ensure they operated as intended.
