### PR TITLE
Create Child Account Form

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -1,5 +1,5 @@
 import AppAxiosInstance from '../auth/axios';
-import { UserData } from '../auth/ducks/types';
+import { SignupRequest, UserData } from '../auth/ducks/types';
 import {
   TeamResponse,
   Applicant,
@@ -57,6 +57,7 @@ export interface ProtectedApiClient {
   readonly changePrivilegeLevel: (
     request: ChangePrivilegeRequest,
   ) => Promise<void>;
+  readonly createChild: (request: SignupRequest) => Promise<void>;
   readonly getUserData: () => Promise<UserData>;
   readonly createTeam: (request: CreateTeamRequest) => Promise<void>;
   readonly getTeams: () => Promise<TeamResponse[]>;
@@ -118,6 +119,7 @@ export enum AdminApiClientRoutes {
   PASS_RESERVATION_QA = '/api/v1/protected/reservations/pass_qa',
   FAIL_RESERVATION_QA = '/api/v1/protected/reservations/fail_qa',
   CHANGE_PRIVILEGE = '/api/v1/protected/user/change_privilege',
+  CREATE_CHILD = '/api/v1/protected/user/create_child',
   GET_ADOPTION_REPORT = '/api/v1/protected/report/adoption',
   GET_STEWARDSHIP_REPORT = '/api/v1/protected/report/stewardship',
 }
@@ -241,6 +243,12 @@ const changePrivilegeLevel = (
     AdminApiClientRoutes.CHANGE_PRIVILEGE,
     request,
   ).then((res) => res.data);
+};
+
+const createChild = (request: SignupRequest): Promise<void> => {
+  return AppAxiosInstance.post(AdminApiClientRoutes.CREATE_CHILD, request).then(
+    (res) => res.data,
+  );
 };
 
 const getUserData = (): Promise<UserData> => {
@@ -417,6 +425,7 @@ const Client: ProtectedApiClient = Object.freeze({
   changeEmail,
   deleteUser,
   changePrivilegeLevel,
+  createChild,
   getUserData,
   createTeam,
   getTeams,

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1389,6 +1389,63 @@ describe('Admin Protected Client Routes', () => {
       expect(result).toEqual(response);
     });
   });
+
+  describe('createChild', () => {
+    it('makes the right request', async () => {
+      const response = new Promise((res) => res);
+
+      nock(BASE_URL)
+        .post(AdminApiClientRoutes.CREATE_CHILD)
+        .reply(200, response);
+
+      const result = ProtectedApiClient.createChild({
+        firstName: 'Test',
+        lastName: 'Last',
+        email: 'test@test.com',
+        username: 'test',
+        password: 'test',
+      });
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request', async () => {
+      const response = 'Invalid email';
+
+      nock(BASE_URL)
+        .post(AdminApiClientRoutes.CREATE_CHILD)
+        .reply(400, response);
+
+      const result = await ProtectedApiClient.createChild({
+        firstName: 'Test',
+        lastName: 'Last',
+        email: 'aterribleemail',
+        username: 'test',
+        password: 'test',
+      }).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes an unauthorized request', async () => {
+      const response = 'Given password is not correct';
+
+      nock(BASE_URL)
+        .post(AdminApiClientRoutes.CREATE_CHILD)
+        .reply(401, response);
+
+      const result = await ProtectedApiClient.createChild({
+        firstName: 'Test',
+        lastName: 'Last',
+        email: 'test@test.com',
+        username: 'test',
+        password: 'test',
+      }).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+  });
+
   describe('editSite', () => {
     it('makes the right request', async () => {
       const response = new Promise((res) => res);

--- a/src/components/forms/signupForm/index.tsx
+++ b/src/components/forms/signupForm/index.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import { Routes } from '../../../App';
-import { Button, Col, Form, Input, Row, Typography } from 'antd';
-import { ParagraphProps } from 'antd/lib/typography/Paragraph';
-import { Link } from 'react-router-dom';
-import { TEXT_GREY } from '../../../utils/colors';
-import styled from 'styled-components';
+import { Form, Input } from 'antd';
 import {
   FormHalfItem,
   FormRow,
   FullWidthSpace,
   Gap,
 } from '../../themedComponents';
-import { WindowTypes } from '../../windowDimensions';
 import { FormInstance } from 'antd/es/form';
 import {
   confirmPasswordRules,
@@ -23,25 +17,15 @@ import {
 } from '../../../utils/formRules';
 import { SignupFormValues } from '../ducks/types';
 
-const offsetSpan = 1;
-
-const Footer: typeof Typography.Paragraph = styled(Typography.Paragraph)<
-  ParagraphProps
->`
-  color: ${TEXT_GREY};
-  line-height: 1.5;
-`;
-
 interface SignupFormProps {
   readonly formInstance: FormInstance;
   readonly onFinish: (values: SignupFormValues) => void;
-  readonly windowType: WindowTypes;
 }
 
 const SignupForm: React.FC<SignupFormProps> = ({
   formInstance,
   onFinish,
-  windowType,
+  children,
 }) => {
   return (
     <>
@@ -73,51 +57,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
             <Input.Password placeholder="Confirm Password" />
           </Form.Item>
         </FullWidthSpace>
-        <div>
-          {(() => {
-            switch (windowType) {
-              case WindowTypes.Mobile:
-                return (
-                  <>
-                    <Form.Item>
-                      <Button type="primary" htmlType="submit" size="large">
-                        Sign Up
-                      </Button>
-                    </Form.Item>
-                    <Footer>
-                      ALREADY HAVE AN ACCOUNT?
-                      <br />
-                      LOGIN <Link to={Routes.LOGIN}>HERE!</Link>
-                    </Footer>
-                  </>
-                );
-              case WindowTypes.Tablet:
-              case WindowTypes.NarrowDesktop:
-              case WindowTypes.Desktop:
-                return (
-                  <>
-                    <Row>
-                      <Col>
-                        <Form.Item>
-                          <Button type="primary" htmlType="submit" size="large">
-                            Sign Up
-                          </Button>
-                        </Form.Item>
-                      </Col>
-                      <Col span={offsetSpan} />
-                      <Col>
-                        <Footer>
-                          ALREADY HAVE AN ACCOUNT?
-                          <br />
-                          LOGIN <Link to={Routes.LOGIN}>HERE!</Link>
-                        </Footer>
-                      </Col>
-                    </Row>
-                  </>
-                );
-            }
-          })()}
-        </div>
+        <div>{children}</div>
       </Form>
     </>
   );

--- a/src/components/themedComponents/index.tsx
+++ b/src/components/themedComponents/index.tsx
@@ -133,15 +133,18 @@ export const InlineImage = styled(Image)`
 `;
 
 export interface FlexProps {
+  margin?: string;
+  gap?: string;
   justifyContent?: string;
 }
 
 export const Flex = styled.div`
+  margin: ${({ margin }: FlexProps) => (margin ? margin : '0')};
   width: 100%;
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
-  gap: 15px 50px;
+  gap: ${({ gap }: FlexProps) => (gap ? gap : '50px')};
   justify-content: ${({ justifyContent }: FlexProps) =>
     justifyContent ? justifyContent : 'flex-start'};
 `;

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { Typography } from 'antd';
+import { Button, Form, message, Typography } from 'antd';
 import PageHeader from '../../components/pageHeader';
 import PageLayout from '../../components/pageLayout';
 import styled from 'styled-components';
@@ -9,21 +9,42 @@ import { C4CState } from '../../store';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { PrivilegeLevel } from '../../auth/ducks/types';
 import ChangePrivilegeForm from '../../components/forms/changePrivilegeForm';
+import SignupForm from '../../components/forms/signupForm';
+import { SignupFormValues } from '../../components/forms/ducks/types';
+import ProtectedApiClient from '../../api/protectedApiClient';
+import { Flex } from '../../components/themedComponents';
+import { AppError } from '../../auth/axios';
+import { getErrorMessage } from '../../utils/stringFormat';
 
 const AdminContentContainer = styled.div`
   margin: 100px auto auto;
   width: 80vw;
 `;
 
-const EditUser = styled.div`
-  margin: 80px 0px 40px;
-  width: 370px;
+const DashboardContent = styled.div`
+  width: 450px;
 `;
 
 const AdminDashboard: React.FC = () => {
   const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(state.authenticationState.tokens),
   );
+  const [createChildForm] = Form.useForm();
+
+  const onCreateChild = (values: SignupFormValues) => {
+    ProtectedApiClient.createChild({
+      email: values.email,
+      username: values.username,
+      password: values.password,
+      firstName: values.firstName,
+      lastName: values.lastName,
+    })
+      .then(() => {
+        message.success(`${values.email} successfully added!`);
+        createChildForm.resetFields();
+      })
+      .catch((error: AppError) => message.error(getErrorMessage(error)));
+  };
 
   return (
     <>
@@ -37,11 +58,28 @@ const AdminDashboard: React.FC = () => {
       <PageLayout>
         <AdminContentContainer>
           <PageHeader pageTitle="Admin Dashboard" />
+          <Flex margin={'60px 0 0 0'} gap={'50px 100px'}>
+            <DashboardContent>
+              <Typography.Title level={4}>Edit Admins</Typography.Title>
+              <ChangePrivilegeForm privilegeLevel={privilegeLevel} />
+            </DashboardContent>
 
-          <EditUser>
-            <Typography.Title level={4}>Edit Admins</Typography.Title>
-            <ChangePrivilegeForm privilegeLevel={privilegeLevel} />
-          </EditUser>
+            <DashboardContent>
+              <Typography.Title level={4}>
+                Create Child Accounts
+              </Typography.Title>
+              <SignupForm
+                formInstance={createChildForm}
+                onFinish={onCreateChild}
+              >
+                <Form.Item>
+                  <Button type="primary" htmlType="submit" size="large">
+                    Create Child Account
+                  </Button>
+                </Form.Item>
+              </SignupForm>
+            </DashboardContent>
+          </Flex>
         </AdminContentContainer>
       </PageLayout>
     </>

--- a/src/containers/signup/index.tsx
+++ b/src/containers/signup/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useLocation } from 'react-router';
-import { useHistory } from 'react-router-dom';
-import { Form, message, Typography } from 'antd';
+import { Link, useHistory } from 'react-router-dom';
+import { Button, Col, Form, message, Row, Typography } from 'antd';
 import { Helmet } from 'react-helmet';
 import GreetingContainer from '../../components/greetingContainer';
 import { getUserData, signup } from '../../auth/ducks/thunks';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { UserAuthenticationReducerState } from '../../auth/ducks/types';
 import { C4CState } from '../../store';
-import { BLACK, WHITE } from '../../utils/colors';
+import { BLACK, TEXT_GREY, WHITE } from '../../utils/colors';
 import styled from 'styled-components';
 import {
   InputContainer,
@@ -24,6 +24,7 @@ import { RedirectStateProps, Routes } from '../../App';
 import { isLoggedIn } from '../../auth/ducks/selectors';
 import { SIGNUP_BODY, SIGNUP_HEADER, SIGNUP_TITLE } from '../../assets/content';
 import { SignupFormValues } from '../../components/forms/ducks/types';
+import { ParagraphProps } from 'antd/lib/typography/Paragraph';
 
 const MobileSignupPageContainer = styled.div`
   padding: 30px;
@@ -39,6 +40,15 @@ const Title = styled(Typography.Paragraph)`
   color: ${BLACK};
   font-size: 30px;
   line-height: 33px;
+`;
+
+const offsetSpan = 1;
+
+const Footer: typeof Typography.Paragraph = styled(Typography.Paragraph)<
+  ParagraphProps
+>`
+  color: ${TEXT_GREY};
+  line-height: 1.5;
 `;
 
 interface SignupProps {
@@ -96,11 +106,18 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
               <>
                 <MobileSignupPageContainer>
                   <PageHeader pageTitle={SIGNUP_TITLE} isMobile={true} />
-                  <SignupForm
-                    formInstance={signupForm}
-                    onFinish={onSignup}
-                    windowType={windowType}
-                  />
+                  <SignupForm formInstance={signupForm} onFinish={onSignup}>
+                    <Form.Item>
+                      <Button type="primary" htmlType="submit" size="large">
+                        Sign Up
+                      </Button>
+                    </Form.Item>
+                    <Footer>
+                      ALREADY HAVE AN ACCOUNT?
+                      <br />
+                      LOGIN <Link to={Routes.LOGIN}>HERE!</Link>
+                    </Footer>
+                  </SignupForm>
                 </MobileSignupPageContainer>
               </>
             );
@@ -113,11 +130,29 @@ const Signup: React.FC<SignupProps> = ({ tokens }) => {
                   <InputContainer>
                     <Title>{SIGNUP_TITLE}</Title>
                     <Line />
-                    <SignupForm
-                      formInstance={signupForm}
-                      onFinish={onSignup}
-                      windowType={windowType}
-                    />
+                    <SignupForm formInstance={signupForm} onFinish={onSignup}>
+                      <Row>
+                        <Col>
+                          <Form.Item>
+                            <Button
+                              type="primary"
+                              htmlType="submit"
+                              size="large"
+                            >
+                              Sign Up
+                            </Button>
+                          </Form.Item>
+                        </Col>
+                        <Col span={offsetSpan} />
+                        <Col>
+                          <Footer>
+                            ALREADY HAVE AN ACCOUNT?
+                            <br />
+                            LOGIN <Link to={Routes.LOGIN}>HERE!</Link>
+                          </Footer>
+                        </Col>
+                      </Row>
+                    </SignupForm>
                   </InputContainer>
 
                   <GreetingContainer


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/27pm2f2)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Allows admins to create child accounts.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Paired with @Tvcz 

Added the route to `protectedApiClient` and added a create child account form to the admin dashboard (reusing signup form).

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Admin Dashboard (Desktop)
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/22990100/166121306-725ee7f1-019c-4103-8d7b-20733026b02b.png">

Admin Dashboard (Mobile)
<img width="392" alt="image" src="https://user-images.githubusercontent.com/22990100/166121324-6d1a340f-6bf7-43a9-a333-d79f7f84c5be.png">

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Added tests for `protectedApiClient` and made sure error messages and success messages showed up appropriately when running locally.