### PR TITLE
Mobile Slidedown

### DIFF
--- a/src/components/slideDown/index.tsx
+++ b/src/components/slideDown/index.tsx
@@ -2,6 +2,11 @@ import React, { useState, useRef } from 'react';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { MID_GREEN, WHITE } from '../../utils/colors';
+import { BREAKPOINT_TABLET } from '../windowDimensions';
+
+interface SlideDownButtonProps {
+  readonly active: boolean;
+}
 
 const SlideDownButton = styled.button`
   background-color: ${MID_GREEN};
@@ -9,6 +14,11 @@ const SlideDownButton = styled.button`
   border: none;
   outline: none;
   transition: background-color 0.4s ease;
+
+  @media (max-width: ${BREAKPOINT_TABLET}px) {
+    padding: ${({ active }: SlideDownButtonProps) => (active ? '5px' : '20px')};
+    transition: padding 0.4s ease;
+  }
 `;
 
 const SlideDownTextDiv = styled.div`
@@ -58,7 +68,7 @@ const SlideDown: React.FC<SlideDownProps> = ({
 
   return (
     <SlideDownSectionDiv>
-      <SlideDownButton onClick={handleClick}>
+      <SlideDownButton onClick={handleClick} active={setActive}>
         {setActive ? <CaretDownStyled /> : <CaretUpStyled />}
       </SlideDownButton>
       <SlideDownContentDiv


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/29xdaqp)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

Makes slidedown button bigger on mobile when it's down so it's easier to use on mobile browsers.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
- Conditional styling of slidedown button

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
<img width="375" alt="image" src="https://user-images.githubusercontent.com/22990100/166161332-e5ba6063-1429-4aaf-aa20-62aa69755340.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/22990100/166161343-6043d085-b274-4d91-9432-76d02df876ef.png">

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually confirmed using Google Dev tools and iPhone