### PR TITLE
Fix 4-character Zip Codes

### DIFF
--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -53,7 +53,7 @@ const TreeInfo: React.FC<TreeProps> = ({
     // TODO change to siteData.city and remove check for zip after data is cleaned
     let baseLocation = `Boston`;
     if (siteData.zip) {
-      baseLocation += ` 0${siteData.zip}`;
+      baseLocation += ` ${siteData.zip}`;
     }
 
     if (siteData.address) {

--- a/src/utils/formRules.tsx
+++ b/src/utils/formRules.tsx
@@ -98,13 +98,8 @@ export const zipCodeRules: Rule[] = [
     message: 'Please enter a valid zip code!',
   },
   {
-    pattern: /[0-9]{4}/,
-    message: 'Zip code must use numbers only',
-  },
-  {
-    len: 4,
-    message:
-      'Zip code must be 4 digits long - enter without leading 0, ex. enter 02125 as 2125',
+    pattern: /^\d{5}$/,
+    message: 'Zip code must be a 5-digit number',
   },
 ];
 

--- a/src/utils/formRules.tsx
+++ b/src/utils/formRules.tsx
@@ -98,8 +98,12 @@ export const zipCodeRules: Rule[] = [
     message: 'Please enter a valid zip code!',
   },
   {
-    pattern: /^\d{5}$/,
-    message: 'Zip code must be a 5-digit number',
+    pattern: /[0-9]{5}/,
+    message: 'Zip code must only consist of numbers',
+  },
+  {
+    len: 5,
+    message: 'Zip code must be 5 digits long',
   },
 ];
 


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/29xbk00)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Change `zipCodeRules` to allow sites to be created/edited with a 5-character numerical zip code (instead of 4). Will update the database so that all zip codes are 5 characters long when this PR gets merged.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Change `zipCodeRules`  so that zip codes must be 5-character numeric values. Also, noticed that there's no input validation in the frontend on submit. The neighborhood dropdown also doesn't display the correct option. Will handle both in separate PRs.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![image](https://user-images.githubusercontent.com/33704204/181869148-deff6a99-eeaa-4cc8-9092-e2d513498693.png)
![image](https://user-images.githubusercontent.com/33704204/181869292-e16fe75b-a67a-4e03-8e02-0604687b49ec.png)
![zip-code-leading-zero](https://user-images.githubusercontent.com/33704204/181867534-a7c07023-b801-4357-b89f-e1c9c286014d.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Verified that the zip code field is green only when given a valid input (i.e. 5-digit number) by testing various cases (e.g. 'a', '1234', '1234a', '123456').
Verified that the zip code updates correctly when clicking on the submit button.