### PR TITLE
Default form options to previous site entry and turn status input field into radio button

### DIFF
--- a/src/components/forms/ducks/types.ts
+++ b/src/components/forms/ducks/types.ts
@@ -1,7 +1,8 @@
+import { CheckboxOptionType } from 'antd/lib/checkbox/Group';
 import moment from 'moment';
 import { PrivilegeLevel, SignupRequest } from '../../../auth/ducks/types';
 
-export const BOOL_RADIO_OPTS = [
+export const BOOL_RADIO_OPTS: CheckboxOptionType[] = [
   { label: 'Yes', value: true },
   { label: 'No', value: false },
 ];

--- a/src/components/forms/ducks/types.ts
+++ b/src/components/forms/ducks/types.ts
@@ -1,19 +1,14 @@
 import { CheckboxOptionType } from 'antd/lib/checkbox/Group';
 import moment from 'moment';
 import { PrivilegeLevel, SignupRequest } from '../../../auth/ducks/types';
+import { SiteEntryStatus } from '../../../containers/treePage/ducks/types';
 
 export const BOOL_RADIO_OPTS: CheckboxOptionType[] = [
   { label: 'Yes', value: true },
   { label: 'No', value: false },
 ];
 
-export enum SiteEntryStatus {
-  ALIVE = 'Alive',
-  DEAD = 'Dead',
-  DEAD_BUT_STANDING = 'Dead but standing',
-}
-
-export const STATUS_RADIO_OPTS = [
+export const STATUS_RADIO_OPTS: CheckboxOptionType[] = [
   { label: SiteEntryStatus.ALIVE, value: SiteEntryStatus.ALIVE },
   { label: SiteEntryStatus.DEAD, value: SiteEntryStatus.DEAD },
   {

--- a/src/components/forms/ducks/types.ts
+++ b/src/components/forms/ducks/types.ts
@@ -6,6 +6,21 @@ export const BOOL_RADIO_OPTS = [
   { label: 'No', value: false },
 ];
 
+export enum SiteEntryStatus {
+  ALIVE = 'Alive',
+  DEAD = 'Dead',
+  DEAD_BUT_STANDING = 'Dead but standing',
+}
+
+export const STATUS_RADIO_OPTS = [
+  { label: SiteEntryStatus.ALIVE, value: SiteEntryStatus.ALIVE },
+  { label: SiteEntryStatus.DEAD, value: SiteEntryStatus.DEAD },
+  {
+    label: SiteEntryStatus.DEAD_BUT_STANDING,
+    value: SiteEntryStatus.DEAD_BUT_STANDING,
+  },
+];
+
 export interface AuthRequest {
   readonly password: string;
 }

--- a/src/components/forms/updateSiteForm/index.tsx
+++ b/src/components/forms/updateSiteForm/index.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
-import { Col, Form, Input, Radio, Row } from 'antd';
+import { Form, Input, Radio, Row, Space } from 'antd';
 import { FormInstance, Rule } from 'antd/es/form';
-import { BOOL_RADIO_OPTS, UpdateSiteRequest } from '../ducks/types';
+import {
+  BOOL_RADIO_OPTS,
+  STATUS_RADIO_OPTS,
+  UpdateSiteRequest,
+} from '../ducks/types';
 import { Flex, SubmitButton } from '../../themedComponents';
 import TitleStack from '../../titleStack';
-import { SiteEntryFields } from '../../../containers/treePage/ducks/types';
+import {
+  SiteEntry,
+  SiteEntryFields,
+} from '../../../containers/treePage/ducks/types';
 import { stringNumberRules } from '../../../utils/formRules';
 import { getSEFieldDisplayName } from '../../../containers/treePage/ducks/selectors';
+import { CheckboxOptionType } from 'antd/es/checkbox/Group';
 
-interface BoolRadioProps {
+interface RadioInputProps {
   readonly name: string;
+  readonly options?: CheckboxOptionType[];
 }
 
-interface StringInputProps extends BoolRadioProps {
+interface StringInputProps extends RadioInputProps {
   readonly placeholder: string;
   readonly rules?: Rule[];
 }
@@ -20,19 +29,28 @@ interface StringInputProps extends BoolRadioProps {
 interface UpdateSiteFormProps {
   readonly formInstance: FormInstance;
   readonly onFinish: (request: UpdateSiteRequest) => void;
+  readonly latestSiteEntry?: SiteEntry;
 }
 
 const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
   formInstance,
   onFinish,
+  latestSiteEntry,
 }) => {
-  const BoolRadioCol: React.FC<BoolRadioProps> = ({ name }) => {
+  const RadioInput: React.FC<RadioInputProps> = ({ name, options }) => {
+    const radioOptions = options ?? BOOL_RADIO_OPTS;
     return (
-      <Col span={6}>
-        <Form.Item name={name}>
-          <Radio.Group options={BOOL_RADIO_OPTS} />
-        </Form.Item>
-      </Col>
+      <Form.Item name={name}>
+        <Radio.Group>
+          <Space direction="vertical">
+            {radioOptions.map((option: CheckboxOptionType) => (
+              <Radio key={option.label as string} value={option.value}>
+                {option.label}
+              </Radio>
+            ))}
+          </Space>
+        </Radio.Group>
+      </Form.Item>
     );
   };
 
@@ -48,173 +66,178 @@ const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
     );
   };
 
+  const formInitialValues = {
+    treePresent: latestSiteEntry?.treePresent ?? false,
+    multistem: latestSiteEntry?.multistem ?? false,
+    discoloring: latestSiteEntry?.discoloring ?? false,
+    leaning: latestSiteEntry?.leaning ?? false,
+    constrictingGrate: latestSiteEntry?.constrictingGrate ?? false,
+    wounds: latestSiteEntry?.wounds ?? false,
+    pooling: latestSiteEntry?.pooling ?? false,
+    stakesWithWires: latestSiteEntry?.stakesWithWires ?? false,
+    stakesWithoutWires: latestSiteEntry?.stakesWithoutWires ?? false,
+    light: latestSiteEntry?.light ?? false,
+    bicycle: latestSiteEntry?.bicycle ?? false,
+    bagEmpty: latestSiteEntry?.bagEmpty ?? false,
+    bagFilled: latestSiteEntry?.bagFilled ?? false,
+    tape: latestSiteEntry?.tape ?? false,
+    suckerGrowth: latestSiteEntry?.suckerGrowth ?? false,
+    raisedBed: latestSiteEntry?.raisedBed ?? false,
+    fence: latestSiteEntry?.fence ?? false,
+    trash: latestSiteEntry?.trash ?? false,
+    wires: latestSiteEntry?.wires ?? false,
+    grate: latestSiteEntry?.grate ?? false,
+    stump: latestSiteEntry?.stump ?? false,
+    status: latestSiteEntry?.status ?? null,
+  };
+
   return (
     <Form
       name="basic"
       form={formInstance}
       onFinish={onFinish}
       style={{ width: '100%' }}
-      initialValues={{
-        treePresent: false,
-        multistem: false,
-        discoloring: false,
-        leaning: false,
-        constrictingGrate: false,
-        wounds: false,
-        pooling: false,
-        stakesWithWires: false,
-        stakesWithoutWires: false,
-        light: false,
-        bicycle: false,
-        bagEmpty: false,
-        bagFilled: false,
-        tape: false,
-        suckerGrowth: false,
-        raisedBed: false,
-        fence: false,
-        trash: false,
-        wires: false,
-        grate: false,
-        stump: false,
-      }}
+      initialValues={formInitialValues}
     >
       <Flex>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.TREE_PRESENT)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.TREE_PRESENT} />
+          <RadioInput name={SiteEntryFields.TREE_PRESENT} />
+        </TitleStack>
+        <TitleStack
+          title={getSEFieldDisplayName(SiteEntryFields.STATUS)}
+          minWidth={'150px'}
+        >
+          <RadioInput
+            name={SiteEntryFields.STATUS}
+            options={STATUS_RADIO_OPTS}
+          />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.STUMP)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.STUMP} />
+          <RadioInput name={SiteEntryFields.STUMP} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.MULTISTEM)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.MULTISTEM} />
+          <RadioInput name={SiteEntryFields.MULTISTEM} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.DISCOLORING)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.DISCOLORING} />
+          <RadioInput name={SiteEntryFields.DISCOLORING} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.LEANING)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.LEANING} />
+          <RadioInput name={SiteEntryFields.LEANING} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.CONSTRICTING_GRATE)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.CONSTRICTING_GRATE} />
+          <RadioInput name={SiteEntryFields.CONSTRICTING_GRATE} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.WOUNDS)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.WOUNDS} />
+          <RadioInput name={SiteEntryFields.WOUNDS} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.POOLING)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.POOLING} />
+          <RadioInput name={SiteEntryFields.POOLING} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.STAKES_WITH_WIRES)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.STAKES_WITH_WIRES} />
+          <RadioInput name={SiteEntryFields.STAKES_WITH_WIRES} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.STAKES_WITHOUT_WIRES)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.STAKES_WITHOUT_WIRES} />
+          <RadioInput name={SiteEntryFields.STAKES_WITHOUT_WIRES} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.LIGHT)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.LIGHT} />
+          <RadioInput name={SiteEntryFields.LIGHT} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.BICYCLE)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.BICYCLE} />
+          <RadioInput name={SiteEntryFields.BICYCLE} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.BAG_EMPTY)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.BAG_EMPTY} />
+          <RadioInput name={SiteEntryFields.BAG_EMPTY} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.BAG_FILLED)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.BAG_FILLED} />
+          <RadioInput name={SiteEntryFields.BAG_FILLED} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.TAPE)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.TAPE} />
+          <RadioInput name={SiteEntryFields.TAPE} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.SUCKER_GROWTH)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.SUCKER_GROWTH} />
+          <RadioInput name={SiteEntryFields.SUCKER_GROWTH} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.RAISED_BED)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.RAISED_BED} />
+          <RadioInput name={SiteEntryFields.RAISED_BED} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.FENCE)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.FENCE} />
+          <RadioInput name={SiteEntryFields.FENCE} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.TRASH)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.TRASH} />
+          <RadioInput name={SiteEntryFields.TRASH} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.WIRES)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.WIRES} />
+          <RadioInput name={SiteEntryFields.WIRES} />
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.GRATE)}
           minWidth={'150px'}
         >
-          <BoolRadioCol name={SiteEntryFields.GRATE} />
+          <RadioInput name={SiteEntryFields.GRATE} />
         </TitleStack>
       </Flex>
 
       <Flex>
-        <TitleStack
-          title={getSEFieldDisplayName(SiteEntryFields.STATUS)}
-          minWidth={'20%'}
-          flexGrow={'1'}
-        >
-          <StringInput placeholder={'Status'} name={SiteEntryFields.STATUS} />
-        </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.GENUS)}
           minWidth={'20%'}
@@ -343,7 +366,7 @@ const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.MATERIAL)}
-          minWidth={'45%'}
+          minWidth={'20%'}
           flexGrow={'1'}
         >
           <StringInput
@@ -353,7 +376,7 @@ const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.TREE_NOTES)}
-          minWidth={'45%'}
+          minWidth={'20%'}
           flexGrow={'1'}
         >
           <StringInput
@@ -363,7 +386,7 @@ const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
         </TitleStack>
         <TitleStack
           title={getSEFieldDisplayName(SiteEntryFields.SITE_NOTES)}
-          minWidth={'45%'}
+          minWidth={'20%'}
           flexGrow={'1'}
         >
           <StringInput

--- a/src/containers/sitePage/index.tsx
+++ b/src/containers/sitePage/index.tsx
@@ -133,6 +133,9 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
             <UpdateSiteForm
               formInstance={updateSiteForm}
               onFinish={onSubmitUpdateSite}
+              latestSiteEntry={
+                site.entries.length ? site.entries[0] : undefined
+              }
             />
           </MarginBottomRow>
         </SitePageContainer>

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -4,7 +4,6 @@ import { ProtectedSiteActions, SiteActions } from './actions';
 import { ApiExtraArgs } from '../../../api/apiClient';
 import { ProtectedApiExtraArgs } from '../../../api/protectedApiClient';
 import { AsyncRequest } from '../../../utils/asyncRequest';
-import { SiteEntryStatus } from '../../../components/forms/ducks/types';
 
 export interface SiteProps {
   siteId: number;
@@ -113,6 +112,12 @@ export interface SiteEntry {
   treeNotes?: string;
   siteNotes?: string;
   adopter?: string;
+}
+
+export enum SiteEntryStatus {
+  ALIVE = 'Alive',
+  DEAD = 'Dead',
+  DEAD_BUT_STANDING = 'Dead but standing',
 }
 
 export interface SplitSiteEntries {

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -4,6 +4,7 @@ import { ProtectedSiteActions, SiteActions } from './actions';
 import { ApiExtraArgs } from '../../../api/apiClient';
 import { ProtectedApiExtraArgs } from '../../../api/protectedApiClient';
 import { AsyncRequest } from '../../../utils/asyncRequest';
+import { SiteEntryStatus } from '../../../components/forms/ducks/types';
 
 export interface SiteProps {
   siteId: number;
@@ -73,7 +74,7 @@ export const SiteEntryFields = {
 export interface SiteEntry {
   id: number;
   updatedAt: number;
-  status?: string;
+  status?: SiteEntryStatus;
   genus?: string;
   species?: string;
   commonName?: string;

--- a/src/containers/treePage/test/selectors.test.ts
+++ b/src/containers/treePage/test/selectors.test.ts
@@ -15,6 +15,7 @@ import {
   ExtraSiteEntryNames,
   MonthYearOption,
   SiteEntryFields,
+  SiteEntryStatus,
 } from '../ducks/types';
 import {
   mapStewardshipToTreeCare,
@@ -110,7 +111,7 @@ describe('Tree Page Selectors', () => {
       {
         id: 0,
         updatedAt: 200,
-        status: 'good',
+        status: SiteEntryStatus.ALIVE,
         species: 'tree',
         genus: 'big',
         circumference: 4,
@@ -119,7 +120,7 @@ describe('Tree Page Selectors', () => {
       {
         id: 1,
         updatedAt: 100,
-        status: 'bad',
+        status: SiteEntryStatus.DEAD,
         species: 'not a tree',
         circumference: 2,
         bicycle: false,
@@ -141,7 +142,7 @@ describe('Tree Page Selectors', () => {
           },
           {
             title: 'Status',
-            value: 'good',
+            value: SiteEntryStatus.ALIVE,
           },
         ],
         extra: [
@@ -186,7 +187,7 @@ describe('Tree Page Selectors', () => {
         },
         {
           title: 'Status',
-          value: 'good',
+          value: SiteEntryStatus.ALIVE,
         },
         {
           title: 'Species',

--- a/src/containers/treePage/test/thunks.test.ts
+++ b/src/containers/treePage/test/thunks.test.ts
@@ -1,4 +1,9 @@
-import { AdoptedSites, StewardshipActivities, SiteProps } from '../ducks/types';
+import {
+  AdoptedSites,
+  StewardshipActivities,
+  SiteProps,
+  SiteEntryStatus,
+} from '../ducks/types';
 import { getSiteData, getAdoptedSites } from '../ducks/thunks';
 import {
   siteData,
@@ -62,7 +67,7 @@ describe('Tree Page Thunks', () => {
           {
             id: 1,
             updatedAt: 200,
-            status: 'good',
+            status: SiteEntryStatus.ALIVE,
             species: 'tree',
             genus: 'big',
             circumference: 4,
@@ -71,7 +76,7 @@ describe('Tree Page Thunks', () => {
           {
             id: 2,
             updatedAt: 100,
-            status: 'bad',
+            status: SiteEntryStatus.DEAD_BUT_STANDING,
             species: 'not a tree',
             circumference: 2,
             bicycle: false,
@@ -182,7 +187,7 @@ describe('Tree Page Thunks', () => {
           {
             id: 1,
             updatedAt: 200,
-            status: 'good',
+            status: SiteEntryStatus.ALIVE,
             species: 'tree',
             genus: 'big',
             circumference: 4,
@@ -191,7 +196,7 @@ describe('Tree Page Thunks', () => {
           {
             id: 2,
             updatedAt: 100,
-            status: 'bad',
+            status: SiteEntryStatus.DEAD,
             species: 'not a tree',
             circumference: 2,
             bicycle: false,


### PR DESCRIPTION
## Why

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Set the default value for the radio buttons in the add site entry form to be the value of the previous (i.e. latest) entry for that site.
Turn `status` into enum `SiteEntryStatus` from `string` and replace the status text field with a radio button.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
The default values for all of the radio buttons are `false` with the exception of `status`, which is `null`.
Create an enum of three values that match the three possible values for `status` (i.e. Alive, Dead, or Dead but standing). If the status radio button isn't selected, the status will be set to `null`.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
![localhost_3000_site_3331239](https://user-images.githubusercontent.com/33704204/183326198-dd088ee6-fc01-4ce7-b078-b5421174843b.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Check that the default values for the radio buttons are correct both when `latestSiteEntry` is and isn't given (including in the `/admin` page).