### PR TITLE
Increase MyTrees sidebar width for desktop devices

### DIFF
--- a/src/components/mapComponents/mapPageComponents/mapPage/index.tsx
+++ b/src/components/mapComponents/mapPageComponents/mapPage/index.tsx
@@ -28,7 +28,7 @@ const MapPage: React.FC<MapPageProps> = ({
       <PageLayout>
         {mapContent}
         <Layout.Sider
-          width={windowType === WindowTypes.Desktop ? '20vw' : '25vw'}
+          width={windowType === WindowTypes.Desktop ? '22vw' : '25vw'}
         >
           <MapSidebar header={sidebarHeader} description={sidebarDescription}>
             {view !== MapViews.TREES && <MapLegend view={view} />}


### PR DESCRIPTION
## Why

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Increase width of the MyTrees sidebar so that both the More Info and Edit Site Page buttons are shown in a single row (only an issue with admin users). Bug introduced in #147 (this is on me)

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Change the width of the sidebar from 20vw to 22wv

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
Before:
![image](https://user-images.githubusercontent.com/33704204/184542047-ed7b7bcd-0956-4b17-a429-7e7113444859.png)

After:
![image](https://user-images.githubusercontent.com/33704204/184542049-20156b73-fdd5-4f8a-8ddf-889b63da4f34.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Checked that the buttons are rendered correctly in both desktop, tablet, and mobile devices