### PR TITLE
Got rid of no site entries bug on tree page

### DIFF
--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -71,7 +71,7 @@ const TreeInfo: React.FC<TreeProps> = ({
             // Display 'Open Planting Site' if no tree has been planted
             // Otherwise, display the tree's commonName or 'Unknown Species' if no commonName exists
             pageTitle={
-              siteData.entries[0] && siteData.entries[0].treePresent
+              siteData.entries[0]?.treePresent
                 ? siteData.entries[0].commonName
                   ? siteData.entries[0].commonName
                   : 'Unknown Species'

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -47,7 +47,7 @@ const TreeInfo: React.FC<TreeProps> = ({
   const history = useHistory();
   const location = useLocation<RedirectStateProps>();
 
-  const adopted = siteData.entries[0].adopter !== null;
+  const adopted = siteData.entries[0] && siteData.entries[0].adopter !== null;
 
   const getSiteLocation = (): string => {
     // TODO change to siteData.city and remove check for zip after data is cleaned
@@ -71,7 +71,7 @@ const TreeInfo: React.FC<TreeProps> = ({
             // Display 'Open Planting Site' if no tree has been planted
             // Otherwise, display the tree's commonName or 'Unknown Species' if no commonName exists
             pageTitle={
-              siteData.entries[0].treePresent
+              siteData.entries[0] && siteData.entries[0].treePresent
                 ? siteData.entries[0].commonName
                   ? siteData.entries[0].commonName
                   : 'Unknown Species'

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -66,18 +66,22 @@ export const getLatestEntry = (
   namesList: Record<string, string>,
 ): Entry[] => {
   if (asyncRequestIsComplete(items)) {
-    return Object.entries(items.result.entries[0]).reduce<Entry[]>(
-      (soFar, [key, value]) => {
-        if (namesList[key] && (value || value === false)) {
-          soFar.push({
-            title: namesList[key],
-            value: booleanToString(value.toString()),
-          });
-        }
-        return soFar;
-      },
-      [],
-    );
+    if (items.result.entries[0]) {
+      return Object.entries(items.result.entries[0]).reduce<Entry[]>(
+        (soFar, [key, value]) => {
+          if (namesList[key] && (value || value === false)) {
+            soFar.push({
+              title: namesList[key],
+              value: booleanToString(value.toString()),
+            });
+          }
+          return soFar;
+        },
+        [],
+      );
+    } else {
+      return [];
+    }
   }
   return [];
 };

--- a/src/containers/treePage/ducks/selectors.ts
+++ b/src/containers/treePage/ducks/selectors.ts
@@ -66,7 +66,7 @@ export const getLatestEntry = (
   namesList: Record<string, string>,
 ): Entry[] => {
   if (asyncRequestIsComplete(items)) {
-    if (items.result.entries[0]) {
+    if (items.result.entries.length > 0) {
       return Object.entries(items.result.entries[0]).reduce<Entry[]>(
         (soFar, [key, value]) => {
           if (namesList[key] && (value || value === false)) {

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -244,7 +244,8 @@ const TreePage: React.FC<TreeProps> = ({
                 {`<`} Return to Tree Map
               </ReturnButton>
 
-              {!siteData.result.entries[0].treePresent && (
+              {(!siteData.result.entries[0] ||
+                !siteData.result.entries[0].treePresent) && (
                 <PlantInstructionContainer
                   message={noTreeMessage}
                   description={treePlantingRequest}


### PR DESCRIPTION
Modified the tree page to do some null checks on the first site entry, in case the site in question has no site entries. 

In the case that a site does not have site entries, it is treated as if there is no tree present at that site.

## Why

[ClickUp Ticket](https://app.clickup.com/t/2rw2w3n)

No change for end-user, but now the console is less clogged with errors that don't convey any additional information.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots

How console would appear previously:
![image](https://user-images.githubusercontent.com/46767048/202861567-e53f87eb-07c2-4f3f-8406-d411f79f978f.png)

Example of previously erroring site now working:
![image](https://user-images.githubusercontent.com/46767048/202861197-4acbb89b-f30b-428e-a4da-68ee1796376f.png)

No error in console:
![image](https://user-images.githubusercontent.com/46767048/202861539-33164cf0-7e3e-464e-9337-2379eeb013fb.png)


## Verification Steps

Checked whether the tree pages for a few sites (ids 3331222, 3331216, 3331217, 3331218) which had no site entries in the dev database `site_entries` table now loaded without any errors in the console.
