### PR TITLE
Hide the legend slider on the landing page by default

### DIFF
--- a/src/containers/landing/index.tsx
+++ b/src/containers/landing/index.tsx
@@ -120,7 +120,7 @@ const Landing: React.FC<LandingProps> = ({ neighborhoods, sites }) => {
                 }
                 returnTo={Routes.LANDING}
               >
-                <SlideDown defaultOpen={true} slideHeight={MOBILE_SLIDE_HEIGHT}>
+                <SlideDown slideHeight={MOBILE_SLIDE_HEIGHT}>
                   <PaddedContent>
                     <MobileLandingBar
                       barHeader={LANDING_TITLE[lang]}


### PR DESCRIPTION
## Why

No relevant ClickUp ticket

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Hide the legend slider on the landing page by default on mobile and tablet devices so that the slider doesn't hide most of the map when users initially visit the landing page.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Hide the legend slider on the landing page by default on mobile and tablet devices.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. --> 
(The map isn't displaying atm but that's ok for now)
![image](https://user-images.githubusercontent.com/33704204/208008433-9b9a94d9-290b-469c-af62-8fe5dfeec55d.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. --> 
Visually verified that the legend slider is initially closed when visiting the landing page on mobile and tablet devices. Visually verified that the legend slider initially stays open on desktop devices.