### PR TITLE
Update Map Pin from Edit Site Form

### DIFF
--- a/src/components/forms/editSiteForm/index.tsx
+++ b/src/components/forms/editSiteForm/index.tsx
@@ -10,16 +10,39 @@ import styled from 'styled-components';
 
 interface EditSiteFormProps {
   readonly formInstance: FormInstance<EditSiteRequest>;
+  readonly onEdit: (formLat: number, formLng: number) => void;
 }
 
 const EditForm = styled(Form)`
   width: 100%;
 `;
 
-const EditSiteForm: React.FC<EditSiteFormProps> = ({ formInstance }) => {
+// function updateMapPin(lat: number, lng: number) {
+//   // If the place does not have a geometry (if the user did not enter a valid location)
+//   const pinLatLng = new google.maps.LatLng(lat, lng);
+//
+//   // Goes to the place they searched for
+//   const pinMarker = new google.maps.Marker();
+//   pinMarker.setPosition(pinLatLng);
+//   zoomToLocation(pinLatLng, map, zoomLevel);
+// }
+
+const EditSiteForm: React.FC<EditSiteFormProps> = ({
+  formInstance,
+  onEdit,
+}) => {
   return (
     <>
-      <EditForm name="basic" form={formInstance}>
+      <EditForm
+        name="basic"
+        form={formInstance}
+        onValuesChange={(changedValues, allValues) => {
+          if (changedValues.lat || changedValues.lng) {
+            // @ts-ignore
+            onEdit(allValues.lat, allValues.lng);
+          }
+        }}
+      >
         <Flex>
           <TitleStack title={'Address'} flexGrow={'1'}>
             <Form.Item

--- a/src/components/forms/editSiteForm/index.tsx
+++ b/src/components/forms/editSiteForm/index.tsx
@@ -17,16 +17,6 @@ const EditForm = styled(Form)`
   width: 100%;
 `;
 
-// function updateMapPin(lat: number, lng: number) {
-//   // If the place does not have a geometry (if the user did not enter a valid location)
-//   const pinLatLng = new google.maps.LatLng(lat, lng);
-//
-//   // Goes to the place they searched for
-//   const pinMarker = new google.maps.Marker();
-//   pinMarker.setPosition(pinLatLng);
-//   zoomToLocation(pinLatLng, map, zoomLevel);
-// }
-
 const EditSiteForm: React.FC<EditSiteFormProps> = ({
   formInstance,
   onEdit,

--- a/src/components/mapComponents/mapDisplays/selectorMapDisplay/index.tsx
+++ b/src/components/mapComponents/mapDisplays/selectorMapDisplay/index.tsx
@@ -20,6 +20,7 @@ interface SelectorMapDisplayProps {
   readonly sites: MapGeoDataReducerState['siteGeoData'];
   readonly onMove: (pos: google.maps.LatLng) => void;
   readonly site?: SiteProps;
+  readonly setMarker: (marker: google.maps.Marker) => void;
 }
 
 const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
@@ -27,6 +28,7 @@ const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
   sites,
   onMove,
   site,
+  setMarker,
 }) => (
   <>
     {asyncRequestIsComplete(neighborhoods) && asyncRequestIsComplete(sites) && (
@@ -35,6 +37,7 @@ const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
         sites={sites.result}
         onMove={onMove}
         site={site}
+        setMarker={setMarker}
       />
     )}
     {(asyncRequestIsFailed(neighborhoods) || asyncRequestIsFailed(sites)) && (

--- a/src/components/mapComponents/maps/selectorMap/index.tsx
+++ b/src/components/mapComponents/maps/selectorMap/index.tsx
@@ -18,6 +18,7 @@ interface SelectorMapProps {
   readonly sites: SiteGeoData;
   readonly onMove: (pos: google.maps.LatLng) => void;
   readonly site?: SiteProps;
+  readonly setMarker: (marker: google.maps.Marker) => void;
 }
 
 const SelectorMap: React.FC<SelectorMapProps> = ({
@@ -25,6 +26,7 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
   sites,
   onMove,
   site,
+  setMarker,
 }) => {
   const defaultZoom = STREET_ZOOM;
 
@@ -48,6 +50,8 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
       draggable: true,
       position: new google.maps.LatLng(defaultCenter.lat, defaultCenter.lng),
     });
+
+    setMarker(searchMarker);
 
     google.maps.event.addListener(searchMarker, 'dragend', () => {
       const latLng = searchMarker.getPosition();

--- a/src/components/siteFeatures/index.tsx
+++ b/src/components/siteFeatures/index.tsx
@@ -16,12 +16,14 @@ interface SiteFeaturesProps {
   readonly site: SiteProps;
   readonly editSiteForm: FormInstance<EditSiteRequest>;
   readonly onSubmit: (request: EditSiteRequest) => void;
+  readonly onEdit: (formLat: number, formLng: number) => void;
 }
 
 const SiteFeatures: React.FC<SiteFeaturesProps> = ({
   site,
   editSiteForm,
   onSubmit,
+  onEdit,
 }) => {
   const [editingFeatures, setEditingFeatures] = useState(false);
 
@@ -41,7 +43,7 @@ const SiteFeatures: React.FC<SiteFeaturesProps> = ({
     case true:
       return (
         <>
-          <EditSiteForm formInstance={editSiteForm} />
+          <EditSiteForm formInstance={editSiteForm} onEdit={onEdit} />
 
           <Flex justifyContent={'flex-end'}>
             <WhiteButton onClick={() => setEditingFeatures(false)}>

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Button, Form, message, Row, Typography, Divider } from 'antd';
 import PageHeader from '../../components/pageHeader';
@@ -69,6 +69,8 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
   const [createChildForm] = Form.useForm();
   const { windowType } = useWindowDimensions();
   const dispatch = useDispatch();
+
+  const [marker, setMarker] = useState<google.maps.Marker>();
 
   const onCreateChild = (values: SignupFormValues) => {
     ProtectedApiClient.createChild({
@@ -153,7 +155,14 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
               <Block
                 maxWidth={windowType === WindowTypes.Mobile ? '100%' : '45%'}
               >
-                <EditSiteForm formInstance={editSiteForm} />
+                <EditSiteForm
+                  formInstance={editSiteForm}
+                  onEdit={(formLat: number, formLng: number) =>
+                    marker?.setPosition(
+                      new google.maps.LatLng(formLat, formLng),
+                    )
+                  }
+                />
               </Block>
               <MapContainer>
                 <SelectorMapDisplay
@@ -165,6 +174,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
                       lng: pos.lng(),
                     });
                   }}
+                  setMarker={setMarker}
                 />
               </MapContainer>
             </Flex>

--- a/src/containers/sitePage/index.tsx
+++ b/src/containers/sitePage/index.tsx
@@ -51,6 +51,7 @@ interface SitePageProps {
 
 const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
   const [site, setSite] = useState<SiteProps>();
+  const [marker, setMarker] = useState<google.maps.Marker>();
   const id = Number(useParams<SiteParams>().id);
   const { windowType } = useWindowDimensions();
   const dispatch = useDispatch();
@@ -108,6 +109,9 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
                 site={site}
                 editSiteForm={editSiteForm}
                 onSubmit={onSubmitEditSite}
+                onEdit={(formLat: number, formLng: number) =>
+                  marker?.setPosition(new google.maps.LatLng(formLat, formLng))
+                }
               />
             </Block>
             <MapContainer>
@@ -121,6 +125,7 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
                   });
                 }}
                 site={site}
+                setMarker={setMarker}
               />
             </MapContainer>
           </Flex>


### PR DESCRIPTION
## Why

[ClickUp Ticket](https://app.clickup.com/t/2v888qn)

Updates the map pin in real time to match the coordinates inputted into the edit site form, similar to how the form updates when the map pin is moved manually.

## This PR

Adds a marker state to the `sitePage` and `adminDashboard` components so that the state of the marker can be accessed in a callback sent down to the `editSiteForm`, which calls the callback when the latitude or longitude values in the form are modified.

## Verification Steps

Manually checked the admin page (`/admin`) and several edit site features pages (`/site/3215646`, `/site/3310969`, `/site/3321019`) to ensure that changing the coordinates on the form moved the pin and that moving the pin still updated the form.
