### PR TITLE
Default site name input to current name and refresh page on name change

### DIFF
--- a/src/components/forms/editTreeNameForm/index.tsx
+++ b/src/components/forms/editTreeNameForm/index.tsx
@@ -11,6 +11,7 @@ interface StyledButtonProps {
 }
 
 interface EditTreeNameFormProps extends StyledButtonProps {
+  readonly treeName: string;
   readonly editTreeNameForm: FormInstance<NameSiteEntryRequest>;
   readonly onSubmitNameChange: () => void;
   readonly onCancelNameChange: () => void;
@@ -37,6 +38,7 @@ const CancelButton = styled(WhiteButton)`
 
 const EditTreeNameForm: React.FC<EditTreeNameFormProps> = ({
   isMobile,
+  treeName,
   editTreeNameForm,
   onSubmitNameChange,
   onCancelNameChange,
@@ -49,7 +51,7 @@ const EditTreeNameForm: React.FC<EditTreeNameFormProps> = ({
       size={isMobile ? 'small' : 'middle'}
     >
       <Form.Item name="name" rules={treeNameRules}>
-        <Input placeholder="Enter tree name" />
+        <Input placeholder="Enter tree name" defaultValue={treeName} />
       </Form.Item>
       <Form.Item>
         <SubmitButton isMobile={isMobile} onClick={onSubmitNameChange}>

--- a/src/components/treePageHeader/index.tsx
+++ b/src/components/treePageHeader/index.tsx
@@ -11,6 +11,10 @@ import {
 import styled from 'styled-components';
 import { EditOutlined } from '@ant-design/icons';
 import { isEmptyString } from '../../utils/isCheck';
+import { getSiteData } from '../../containers/treePage/ducks/thunks';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { TreeParams } from '../../containers/treePage';
 
 interface TreePageHeaderProps extends StyledSubtitleProps {
   readonly pageTitle: string;
@@ -51,6 +55,8 @@ const TreePageHeader: React.FC<TreePageHeaderProps> = ({
   subtitlecolor,
 }) => {
   const [editingTreeName, setEditingTreeName] = useState<boolean>(false);
+  const siteId = Number(useParams<TreeParams>().id);
+  const dispatch = useDispatch();
 
   const treeDisplayName = !isEmptyString(unescape(treeName))
     ? unescape(treeName)
@@ -62,6 +68,7 @@ const TreePageHeader: React.FC<TreePageHeaderProps> = ({
     setEditingTreeName(false);
     const newTreeName = editTreeNameForm.getFieldValue('name');
     onClickEditTreeName({ name: escape(newTreeName) });
+    dispatch(getSiteData(siteId));
   };
 
   return (
@@ -71,6 +78,7 @@ const TreePageHeader: React.FC<TreePageHeaderProps> = ({
         <EditTreeNameForm
           editTreeNameForm={editTreeNameForm}
           isMobile={isMobile}
+          treeName={treeName}
           onSubmitNameChange={onTreeNameChange}
           onCancelNameChange={() => setEditingTreeName(false)}
         />

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -110,7 +110,7 @@ interface TreeProps {
   readonly adoptedSites: ProtectedSitesReducerState['adoptedSites'];
 }
 
-interface TreeParams {
+export interface TreeParams {
   id: string;
 }
 


### PR DESCRIPTION
## Checklist

- [X] 1. Run `npm run check`
- [X] 2. Run `npm run test`
- [x] 3. Change ClickUp ticket status to "In Review"
- [x] 4. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/862j171zh)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
1. Default the value of site name text input to be the current name so that the user won't have to type the entire site name when changing just a few characters
2. Refresh the page when the user changes the name of a site so that the user sees that the site name was changed without having to manually refresh the page

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
1. Set the default value of the text input in `EditTreeNameForm` to be the current tree name, if applicable
2. Use the `useDispatch` hook to get the updated site data and thus trigger a re-render of the component

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Visually verified that the default value of the tree name input is the current site name both when the site has and doesn't have a name

Tried changing the site name to arbitrary text (including empty text to delete the site's name) and visually verified that the component re-renders (i.e. the page refreshes)