### PR TITLE
Increase clickable area on profile dropdown

### DIFF
--- a/src/components/navBar/navMenu/index.tsx
+++ b/src/components/navBar/navMenu/index.tsx
@@ -19,6 +19,8 @@ const StyledNavMenuItem = styled(Menu.Item)`
 const MenuLinkButton = styled(LinkButton)`
   padding-left: 0;
   margin-top: 0;
+  width: 100%;
+  text-align: left;
 `;
 
 interface NavMenuProps {


### PR DESCRIPTION
## Checklist

- [X] 1. Run `npm run check`
- [X] 2. Run `npm run test`
- [X] 3. Change ClickUp ticket status to "In Review"
- [X] 4. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/36gw2rk)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Increase clickable area on the profile dropdown menu so that users will be able to click on some of the menu items (especially "My Trees" and "Admins") more easily.

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Make the menu items in the dropdown take up 100% of their parents' widths.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->
Note: the purpose of the background colors are just to visually see where the clickable areas for each menu item are and are not shown to users. For the first three menu items, the red areas are the clickable areas and for the last menu item, the green area is its clickable area.
![image](https://user-images.githubusercontent.com/33704204/214469076-69c914f0-6d4f-481f-a319-374a9a39ea8b.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Added background colors to make sure that the clickable areas increased and manually clicked on each menu item to ensure that the clickable areas are, in fact, clickable.
