### PR TITLE
Round lat/lng when moving map pin in add/edit site forms

### DIFF
--- a/src/components/forms/constants.ts
+++ b/src/components/forms/constants.ts
@@ -1,0 +1,1 @@
+export const LAT_LNG_PRECISION = 6;

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -30,6 +30,8 @@ import { SignupFormValues } from '../../components/forms/ducks/types';
 import ProtectedApiClient from '../../api/protectedApiClient';
 import { AppError } from '../../auth/axios';
 import { getErrorMessage } from '../../utils/stringFormat';
+import { round } from 'lodash';
+import { LAT_LNG_PRECISION } from '../../components/forms/constants';
 
 const AdminContentContainer = styled.div`
   width: 80vw;
@@ -166,8 +168,8 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
                   sites={sites}
                   onMove={(pos: google.maps.LatLng) => {
                     editSiteForm.setFieldsValue({
-                      lat: pos.lat(),
-                      lng: pos.lng(),
+                      lat: round(pos.lat(), LAT_LNG_PRECISION),
+                      lng: round(pos.lng(), LAT_LNG_PRECISION),
                     });
                   }}
                 />

--- a/src/containers/sitePage/index.tsx
+++ b/src/containers/sitePage/index.tsx
@@ -24,6 +24,8 @@ import {
 import SelectorMapDisplay from '../../components/mapComponents/mapDisplays/selectorMapDisplay';
 import { getMapGeoData } from '../../components/mapComponents/ducks/thunks';
 import { Block, Flex, MapContainer } from '../../components/themedComponents';
+import { round } from 'lodash';
+import { LAT_LNG_PRECISION } from '../../components/forms/constants';
 
 const SitePageContainer = styled.div`
   width: 90%;
@@ -116,8 +118,8 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
                 sites={sites}
                 onMove={(pos: google.maps.LatLng) => {
                   editSiteForm.setFieldsValue({
-                    lat: pos.lat(),
-                    lng: pos.lng(),
+                    lat: round(pos.lat(), LAT_LNG_PRECISION),
+                    lng: round(pos.lng(), LAT_LNG_PRECISION),
                   });
                 }}
                 site={site}


### PR DESCRIPTION
## Checklist

- [ ] 1. Run `npm run check`
- [ ] 2. Run `npm run test`
- [ ] 3. Change ClickUp ticket status to "In Review"
- [ ] 4. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/xxxxxxx)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Round latitude and longitude to the nearest 6 decimals when moving the map pin

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
