### PR TITLE
Connect force unadopt site route

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -84,6 +84,7 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly adoptSite: (siteId: number) => Promise<void>;
   readonly unadoptSite: (siteId: number) => Promise<void>;
+  readonly forceUnadoptSite: (siteId: number) => Promise<void>;
   readonly recordStewardship: (
     siteId: number,
     request: ActivityRequest,
@@ -171,6 +172,8 @@ export const ParameterizedApiRoutes = {
     `${baseTeamRoute}${teamId}/transfer_ownership`,
   ADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/adopt`,
   UNADOPT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/unadopt`,
+  FORCE_UNADOPT_SITE: (siteId: number): string =>
+    `${baseSiteRoute}${siteId}/force_unadopt`,
   RECORD_STEWARDSHIP: (siteId: number): string =>
     `${baseSiteRoute}${siteId}/record_stewardship`,
   EDIT_STEWARDSHIP: (activityId: number): string =>
@@ -392,6 +395,12 @@ const unadoptSite = (siteId: number): Promise<void> => {
   ).then((res) => res.data);
 };
 
+const forceUnadoptSite = (siteId: number): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.FORCE_UNADOPT_SITE(siteId),
+  ).then((res) => res.data);
+};
+
 const recordStewardship = (
   siteId: number,
   request: ActivityRequest,
@@ -528,6 +537,7 @@ const Client: ProtectedApiClient = Object.freeze({
   transferOwnership,
   adoptSite,
   unadoptSite,
+  forceUnadoptSite,
   recordStewardship,
   editStewardship,
   deleteStewardship,

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1082,7 +1082,7 @@ describe('Protected API Client Tests', () => {
 
   // Site tests
   describe('Protected Site Tests', () => {
-    describe('Add a site', () => {
+    describe('addSite', () => {
       it('makes the right request', async () => {
         const response = '';
 
@@ -1204,7 +1204,47 @@ describe('Protected API Client Tests', () => {
       });
     });
 
-    describe('Adopt a site', () => {
+    describe('addSites', () => {
+      it('makes the right request', async () => {
+        const response = '';
+
+        nock(BASE_URL)
+          .post(AdminApiClientRoutes.ADD_SITES)
+          .reply(200, response);
+
+        const testGoodAddSitesRequest = {
+          csvText:
+            'lat,lng,city,zip,address,neighborhood,treePresent,status,genus,species,commonName,confidence,diameter,circumference,multistem,coverage,pruning,condition,discoloring,leaning,constrictingGrate,wounds,pooling,stakesWithWires,stakesWithoutWires,light,bicycle,bagEmpty,bagFilled,tape,suckerGrowth,siteType,sidewalkWidth,siteWidth,siteLength,material,raisedBed,fence,trash,wires,grate,stump,treeNotes,siteNotes\n' +
+            '48.58903249,-75.2434242,Boston,12345,Columbus Ave,Back Bay,TRUE,Alive,Genus,Species,Common Name,Confidence,10.2,92,TRUE,coverage,pruning,very good condition,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,Site type,sidewalk width,193.233,1023,material,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,Notes on trees,Notes on sites',
+        };
+        const result = await ProtectedApiClient.addSites(
+          testGoodAddSitesRequest,
+        );
+
+        expect(result).toEqual(response);
+      });
+
+      it('makes a bad request', async () => {
+        const response = 'No such site';
+
+        nock(BASE_URL)
+          .post(AdminApiClientRoutes.ADD_SITES)
+          .reply(400, response);
+
+        const testBadAddSitesRequest = {
+          csvText:
+            'lat,lng,city,zip,address,neighborhood,treePresent,status,genus,species,commonName,confidence,diameter,circumference,multistem,coverage,pruning,condition,discoloring,leaning,constrictingGrate,wounds,pooling,stakesWithWires,stakesWithoutWires,light,bicycle,bagEmpty,bagFilled,tape,suckerGrowth,siteType,sidewalkWidth,siteWidth,siteLength,material\n' +
+            '48.58903249,-75.2434242,Boston,12345,Columbus Ave,Back Bay,TRUE,Alive,Genus,Species,Common Name,Confidence,10.2,92,TRUE,TRUE,Site type,sidewalk width,193.233,1023,material,TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,Notes on trees,Notes on sites',
+        };
+        const result = await ProtectedApiClient.addSites(
+          testBadAddSitesRequest,
+        ).catch((err) => err.response.data);
+
+        expect(result).toEqual(response);
+      });
+    });
+
+    describe('adoptSite', () => {
       it('makes the right request', async () => {
         const response = '';
 
@@ -1232,7 +1272,7 @@ describe('Protected API Client Tests', () => {
       });
     });
 
-    describe('Unadopt a site', () => {
+    describe('unadoptSite', () => {
       it('makes the right request', async () => {
         const response = '';
 
@@ -1260,7 +1300,35 @@ describe('Protected API Client Tests', () => {
       });
     });
 
-    describe('Record stewardship', () => {
+    describe('forceUnadoptSite', () => {
+      it('makes the right request', async () => {
+        const response = '';
+
+        nock(BASE_URL)
+          .post(ParameterizedApiRoutes.FORCE_UNADOPT_SITE(1))
+          .reply(200, response);
+
+        const result = await ProtectedApiClient.forceUnadoptSite(1);
+
+        expect(result).toEqual(response);
+      });
+
+      it('makes a bad request', async () => {
+        const response = 'Was not adopted';
+
+        nock(BASE_URL)
+          .post(ParameterizedApiRoutes.FORCE_UNADOPT_SITE(1))
+          .reply(400, response);
+
+        const result = await ProtectedApiClient.forceUnadoptSite(1).catch(
+          (err) => err.response.data,
+        );
+
+        expect(result).toEqual(response);
+      });
+    });
+
+    describe('recordStewardship', () => {
       it('makes the right request', async () => {
         const response = '';
 
@@ -1298,7 +1366,63 @@ describe('Protected API Client Tests', () => {
       });
     });
 
-    describe('Delete stewardship', () => {
+    describe('editStewardship', () => {
+      it('makes the right request', async () => {
+        const response = '';
+
+        nock(BASE_URL)
+          .post(ParameterizedApiRoutes.EDIT_STEWARDSHIP(1))
+          .reply(200, response);
+
+        const result = await ProtectedApiClient.editStewardship(1, {
+          date: '10/12/2020',
+          watered: true,
+          mulched: false,
+          cleaned: true,
+          weeded: false,
+        });
+
+        expect(result).toEqual(response);
+      });
+
+      it('makes a bad request', async () => {
+        const response = 'all false';
+
+        nock(BASE_URL)
+          .post(ParameterizedApiRoutes.EDIT_STEWARDSHIP(1))
+          .reply(400, response);
+
+        const result = await ProtectedApiClient.editStewardship(1, {
+          date: '10/12/2020',
+          watered: false,
+          mulched: false,
+          cleaned: false,
+          weeded: false,
+        }).catch((err) => err.response.data);
+
+        expect(result).toEqual(response);
+      });
+
+      it('makes an unauthorized request', async () => {
+        const response = 'Must be admin or author';
+
+        nock(BASE_URL)
+          .post(ParameterizedApiRoutes.EDIT_STEWARDSHIP(1))
+          .reply(401, response);
+
+        const result = await ProtectedApiClient.editStewardship(1, {
+          date: '10/12/2020',
+          watered: true,
+          mulched: false,
+          cleaned: true,
+          weeded: false,
+        }).catch((err) => err.response.data);
+
+        expect(result).toEqual(response);
+      });
+    });
+
+    describe('deleteStewardship', () => {
       it('makes the right request', async () => {
         const response = '';
 
@@ -1340,7 +1464,7 @@ describe('Protected API Client Tests', () => {
       });
     });
 
-    describe('Get adopted sites', () => {
+    describe('getAdoptedSites', () => {
       it('makes the right request', async () => {
         const response = {
           adoptedSites: [1, 2, 3],
@@ -1357,7 +1481,7 @@ describe('Protected API Client Tests', () => {
     });
   });
 
-  describe('Update site', () => {
+  describe('updateSite', () => {
     it('makes the right request', async () => {
       const response = {};
 
@@ -1774,6 +1898,50 @@ describe('Admin Protected Client Routes', () => {
       const result = await ProtectedApiClient.getStewardshipReportCsv(10).catch(
         (err) => err.response.data,
       );
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('nameSiteEntry', () => {
+    it('makes the right request', async () => {
+      const response = '';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.NAME_SITE_ENTRY(1))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.nameSiteEntry(1, {
+        name: 'New name',
+      });
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request', async () => {
+      const response = 'Name too long';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.NAME_SITE_ENTRY(1))
+        .reply(400, response);
+
+      const result = await ProtectedApiClient.nameSiteEntry(1, {
+        name: 'A'.repeat(61),
+      }).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes an unauthorized request ', async () => {
+      const response = 'Must be an admin';
+
+      nock(BASE_URL)
+        .post(ParameterizedApiRoutes.NAME_SITE_ENTRY(1))
+        .reply(401, response);
+
+      const result = await ProtectedApiClient.nameSiteEntry(1, {
+        name: 'New name',
+      }).catch((err) => err.response.data);
 
       expect(result).toEqual(response);
     });

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -34,6 +34,10 @@ const UnadoptButton = styled(Button)`
   }
 `;
 
+const ForceUnadoptButton = styled(Button)`
+  margin: 10px;
+`;
+
 interface TreeProps {
   readonly siteData: SiteProps;
   readonly loggedIn: boolean;
@@ -41,6 +45,7 @@ interface TreeProps {
   readonly mobile?: boolean;
   readonly onClickAdopt: () => void;
   readonly onClickUnadopt: () => void;
+  readonly onClickForceUnadopt: () => void;
   readonly onFinishRecordStewardship: (
     values: RecordStewardshipRequest,
   ) => void;
@@ -56,6 +61,7 @@ const TreeInfo: React.FC<TreeProps> = ({
   mobile,
   onClickAdopt,
   onClickUnadopt,
+  onClickForceUnadopt,
   onFinishRecordStewardship,
   stewardshipFormInstance,
   editTreeNameFormInstance,
@@ -64,7 +70,7 @@ const TreeInfo: React.FC<TreeProps> = ({
   const history = useHistory();
   const location = useLocation<RedirectStateProps>();
 
-  const adopted = siteData.entries[0] && siteData.entries[0].adopter !== null;
+  const isAdopted = !!siteData.entries?.[0]?.adopter;
 
   const userIsAdmin: boolean = useSelector((state: C4CState) =>
     isAdmin(state.authenticationState.tokens),
@@ -90,7 +96,7 @@ const TreeInfo: React.FC<TreeProps> = ({
       defaultText={
         userOwnsTree
           ? 'Check out this tree I adopted!'
-          : adopted
+          : isAdopted
           ? 'Check out this tree near you!'
           : `This tree${
               siteData.address ? ' at ' + siteData.address : ''
@@ -125,67 +131,73 @@ const TreeInfo: React.FC<TreeProps> = ({
         }
       </TreeHeader>
 
-      {(() => {
-        switch (loggedIn) {
-          case true:
-            return (
-              <>
-                {userOwnsTree ? (
-                  <>
-                    <UnadoptButton
-                      danger
-                      size={mobile ? 'middle' : 'large'}
-                      onClick={onClickUnadopt}
-                    >
-                      Unadopt
-                    </UnadoptButton>
-                    {shareButton}
-                    <StewardshipContainer>
-                      <Typography.Title level={3}>
-                        Record your tree care activity below.
-                      </Typography.Title>
-                      <StewardshipForm
-                        onFinish={onFinishRecordStewardship}
-                        form={stewardshipFormInstance}
-                      />
-                    </StewardshipContainer>
-                  </>
-                ) : (
-                  <>
-                    <Button
-                      type="primary"
-                      size={mobile ? 'middle' : 'large'}
-                      onClick={onClickAdopt}
-                      disabled={adopted}
-                    >
-                      {adopted ? 'Already Adopted' : 'Adopt'}
-                    </Button>
-                    {shareButton}
-                  </>
-                )}
-              </>
-            );
-          case false:
-            return (
-              <>
-                <ToggleTextButton
-                  type="link"
-                  size="large"
-                  onClick={() =>
-                    history.push(Routes.LOGIN, {
-                      destination: location.pathname,
-                    })
-                  }
-                >
-                  Log in to adopt this tree!
-                </ToggleTextButton>
-                {shareButton}
-              </>
-            );
-        }
-      })()}
+      {loggedIn ? (
+        <>
+          {userOwnsTree ? (
+            <UnadoptButton
+              danger
+              size={mobile ? 'middle' : 'large'}
+              onClick={onClickUnadopt}
+            >
+              Unadopt
+            </UnadoptButton>
+          ) : (
+            <Button
+              type="primary"
+              size={mobile ? 'middle' : 'large'}
+              onClick={onClickAdopt}
+              disabled={isAdopted}
+            >
+              {isAdopted ? 'Already Adopted' : 'Adopt'}
+            </Button>
+          )}
+
+          {userIsAdmin && (
+            <ForceUnadoptButton
+              danger
+              size={mobile ? 'middle' : 'large'}
+              onClick={onClickForceUnadopt}
+              disabled={!isAdopted}
+            >
+              Force Unadopt
+            </ForceUnadoptButton>
+          )}
+
+          {shareButton}
+
+          {userOwnsTree && (
+            <StewardshipContainer>
+              <Typography.Title level={3}>
+                Record your tree care activity below.
+              </Typography.Title>
+              <StewardshipForm
+                onFinish={onFinishRecordStewardship}
+                form={stewardshipFormInstance}
+              />
+            </StewardshipContainer>
+          )}
+        </>
+      ) : (
+        <>
+          <ToggleTextButton
+            type="link"
+            size="large"
+            onClick={() =>
+              history.push(Routes.LOGIN, {
+                destination: location.pathname,
+              })
+            }
+          >
+            Log in to adopt this tree!
+          </ToggleTextButton>
+          {shareButton}
+        </>
+      )}
     </>
   );
 };
 
 export default TreeInfo;
+function dispatch(arg0: any) {
+  throw new Error('Function not implemented.');
+}

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -198,6 +198,3 @@ const TreeInfo: React.FC<TreeProps> = ({
 };
 
 export default TreeInfo;
-function dispatch(arg0: any) {
-  throw new Error('Function not implemented.');
-}

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -6,7 +6,7 @@ import { Col, Form, message, Row, Typography, Alert } from 'antd';
 import { RedirectStateProps, Routes } from '../../App';
 import { Helmet } from 'react-helmet';
 import { UserAuthenticationReducerState } from '../../auth/ducks/types';
-import { isAdmin, isLoggedIn } from '../../auth/ducks/selectors';
+import { isLoggedIn } from '../../auth/ducks/selectors';
 import {
   ActivityRequest,
   MonthYearOption,

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -6,7 +6,7 @@ import { Col, Form, message, Row, Typography, Alert } from 'antd';
 import { RedirectStateProps, Routes } from '../../App';
 import { Helmet } from 'react-helmet';
 import { UserAuthenticationReducerState } from '../../auth/ducks/types';
-import { isLoggedIn } from '../../auth/ducks/selectors';
+import { isAdmin, isLoggedIn } from '../../auth/ducks/selectors';
 import {
   ActivityRequest,
   MonthYearOption,
@@ -160,6 +160,7 @@ const TreePage: React.FC<TreeProps> = ({
       .adoptSite(id)
       .then(() => {
         message.success('Adopted site!');
+        dispatch(getSiteData(id));
         dispatch(getAdoptedSites());
       })
       .catch((err) => {
@@ -177,6 +178,19 @@ const TreePage: React.FC<TreeProps> = ({
       })
       .catch((err) => {
         message.error(`Failed to unadopt site: ${err.response.data}`);
+      });
+  };
+
+  const onClickForceUnadopt = () => {
+    protectedApiClient
+      .forceUnadoptSite(id)
+      .then(() => {
+        message.success('Force unadopted site!');
+        dispatch(getSiteData(id));
+        dispatch(getAdoptedSites());
+      })
+      .catch((err) => {
+        message.error(`Failed to force unadopt site: ${err.response.data}`);
       });
   };
 
@@ -281,6 +295,7 @@ const TreePage: React.FC<TreeProps> = ({
                                 userOwnsTree={doesUserOwnTree}
                                 onClickAdopt={onClickAdopt}
                                 onClickUnadopt={onClickUnadopt}
+                                onClickForceUnadopt={onClickForceUnadopt}
                                 onFinishRecordStewardship={
                                   onFinishRecordStewardship
                                 }
@@ -316,6 +331,7 @@ const TreePage: React.FC<TreeProps> = ({
                             userOwnsTree={doesUserOwnTree}
                             onClickAdopt={onClickAdopt}
                             onClickUnadopt={onClickUnadopt}
+                            onClickForceUnadopt={onClickForceUnadopt}
                             onFinishRecordStewardship={
                               onFinishRecordStewardship
                             }
@@ -342,6 +358,7 @@ const TreePage: React.FC<TreeProps> = ({
                           mobile={true}
                           onClickAdopt={onClickAdopt}
                           onClickUnadopt={onClickUnadopt}
+                          onClickForceUnadopt={onClickForceUnadopt}
                           onFinishRecordStewardship={onFinishRecordStewardship}
                           stewardshipFormInstance={stewardshipFormInstance}
                           editTreeNameFormInstance={editTreeNameFormInstance}


### PR DESCRIPTION
## Checklist

- [x] 1. Run `npm run check`
- [x] 2. Run `npm run test`
- [x] 3. Change ClickUp ticket status to "In Review"
- [x] 4. After making the PR, add PR link to ClickUp ticket

## Why

[ClickUp Ticket](https://app.clickup.com/t/1dk46ne)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Allow admin users to force unadopt a site (even though showing the adopter's email is part of this ticket, I don't think it's worth it given that it can (relatively easily) be done through the reports page)

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Add a force unadopt site button (for admin users only) that allows admins to force a user to unadopt a site

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->
![image](https://user-images.githubusercontent.com/33704204/229675110-63cc9676-fce0-4a7b-854c-7b402df154d1.png)

![image](https://user-images.githubusercontent.com/33704204/229675143-b90ea359-9c1b-446c-8903-7d126c338b86.png)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Check that the force unadopt button appears only when the users is admin and successfully unadopts the given site, even if the admin is not the site's adopter
