### PR TITLE
Ah.admin redesign

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { logout } from './auth/ducks/thunks';
 import history from './history';
 import FAQ from './containers/faq';
 import Email from './containers/email';
+import AddSites from './containers/addSites';
 
 const AppLayout = styled(Layout)`
   min-height: 100vh;
@@ -72,6 +73,7 @@ export enum Routes {
   FORGOT_PASSWORD_REQUEST = '/forgot-password',
   FORGOT_PASSWORD_RESET = '/forgot-password-reset/:key',
   EMAIL = '/email',
+  ADD_SITES = '/add-sites',
   NOT_FOUND = '*',
 }
 
@@ -269,6 +271,11 @@ const App: React.FC = () => {
                       />
                       <Route path={Routes.REPORTS} exact component={Reports} />
                       <Route path={Routes.EMAIL} exact component={Email} />
+                      <Route
+                        path={Routes.ADD_SITES}
+                        exact
+                        component={AddSites}
+                      />
                       <Route
                         path={Routes.NOT_FOUND}
                         exact

--- a/src/containers/addSites/index.tsx
+++ b/src/containers/addSites/index.tsx
@@ -16,7 +16,13 @@ import {
 import { getMapGeoData } from '../../components/mapComponents/ducks/thunks';
 import { MapGeoDataReducerState } from '../../components/mapComponents/ducks/types';
 import { Typography, Row, Form, Divider, message } from 'antd';
-import { MapContainer, Block, Flex } from '../../components/themedComponents';
+import {
+  MapContainer,
+  Block,
+  Flex,
+  ReturnButton,
+  PaddedPageContainer,
+} from '../../components/themedComponents';
 import useWindowDimensions, {
   WindowTypes,
 } from '../../components/windowDimensions';
@@ -26,11 +32,7 @@ import { MapTypes } from '../../context/types';
 import { MapTypeContext } from '../../context/mapTypeContext';
 import PageLayout from '../../components/pageLayout';
 import PageHeader from '../../components/pageHeader';
-
-const ContentContainer = styled.div`
-  width: 80vw;
-  margin: 8vh auto auto;
-`;
+import { Routes } from '../../App';
 
 const SectionHeader = styled(Typography.Text)`
   font-weight: bold;
@@ -102,7 +104,8 @@ const AddSites: React.FC<AddSitesProps> = ({ neighborhoods, sites }) => {
         />
       </Helmet>
       <PageLayout>
-        <ContentContainer>
+        <PaddedPageContainer>
+          <ReturnButton to={Routes.ADMIN}>{'<'} Back to Dashboard</ReturnButton>
           <PageHeader pageTitle="Add Sites" />
           <DashboardContent>
             <Typography.Title level={4}>Bulk Add Sites</Typography.Title>
@@ -143,7 +146,7 @@ const AddSites: React.FC<AddSitesProps> = ({ neighborhoods, sites }) => {
               onFinish={onSubmitAddSite}
             />
           </MarginBottomRow>
-        </ContentContainer>
+        </PaddedPageContainer>
       </PageLayout>
     </>
   );

--- a/src/containers/addSites/index.tsx
+++ b/src/containers/addSites/index.tsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect } from 'react';
+import { C4CState } from '../../store';
+import { Helmet } from 'react-helmet';
+import styled from 'styled-components';
+import { connect, useDispatch } from 'react-redux';
+import UpdateSiteForm from '../../components/forms/updateSiteForm';
+import EditSiteForm from '../../components/forms/editSiteForm';
+import SelectorMapDisplay from '../../components/mapComponents/mapDisplays/selectorMapDisplay';
+import UploadSitesForm from '../../components/forms/uploadSitesForm';
+import { DARK_GREEN } from '../../utils/colors';
+import ProtectedClient from '../../api/protectedApiClient';
+import {
+  AddSiteRequest,
+  UpdateSiteRequest,
+} from '../../components/forms/ducks/types';
+import { getMapGeoData } from '../../components/mapComponents/ducks/thunks';
+import { MapGeoDataReducerState } from '../../components/mapComponents/ducks/types';
+import { Typography, Row, Form, Divider, message } from 'antd';
+import { MapContainer, Block, Flex } from '../../components/themedComponents';
+import useWindowDimensions, {
+  WindowTypes,
+} from '../../components/windowDimensions';
+import { round } from 'lodash';
+import { LAT_LNG_PRECISION } from '../../components/forms/constants';
+import { MapTypes } from '../../context/types';
+import { MapTypeContext } from '../../context/mapTypeContext';
+import PageLayout from '../../components/pageLayout';
+import PageHeader from '../../components/pageHeader';
+
+const ContentContainer = styled.div`
+  width: 80vw;
+  margin: 8vh auto auto;
+`;
+
+const SectionHeader = styled(Typography.Text)`
+  font-weight: bold;
+  font-size: 20px;
+  color: ${DARK_GREEN};
+`;
+
+const MarginBottomRow = styled(Row)`
+  margin-bottom: 30px;
+`;
+
+const DashboardContent = styled.div`
+  width: 450px;
+`;
+
+const MarginDivider = styled(Divider)`
+  margin: 20px 0px;
+`;
+
+interface AddSitesProps {
+  readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
+  readonly sites: MapGeoDataReducerState['siteGeoData'];
+}
+
+const AddSites: React.FC<AddSitesProps> = ({ neighborhoods, sites }) => {
+  const { windowType } = useWindowDimensions();
+  const dispatch = useDispatch();
+
+  const [mapSearchMarker, setMapSearchMarker] = useState<google.maps.Marker>();
+
+  const [mapTypeId, setMapTypeId] = useState<MapTypes>(MapTypes.ROADMAP);
+
+  const [editSiteForm] = Form.useForm();
+  const [updateSiteForm] = Form.useForm();
+
+  useEffect(() => {
+    dispatch(getMapGeoData());
+  }, [dispatch]);
+
+  const onSubmitAddSite = (request: UpdateSiteRequest) => {
+    editSiteForm.validateFields().then();
+    const addSiteRequest: AddSiteRequest = {
+      blockId: editSiteForm.getFieldValue('blockId'),
+      lat: editSiteForm.getFieldValue('lat'),
+      lng: editSiteForm.getFieldValue('lng'),
+      city: editSiteForm.getFieldValue('city'),
+      zip: editSiteForm.getFieldValue('zip'),
+      address: editSiteForm.getFieldValue('address'),
+      neighborhoodId: editSiteForm.getFieldValue('neighborhoodId'),
+      ...request,
+      plantingDate: updateSiteForm.getFieldValue('plantingDate')?.format('L'),
+    };
+    ProtectedClient.addSite(addSiteRequest)
+      .then(() => {
+        editSiteForm.resetFields();
+        updateSiteForm.resetFields();
+        message.success('Site added!').then();
+      })
+      .catch((err) => message.error(err.response.data));
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>Add Sites</title>
+        <meta
+          name="description"
+          content="The page for admin users add and update site information"
+        />
+      </Helmet>
+      <PageLayout>
+        <ContentContainer>
+          <PageHeader pageTitle="Add Sites" />
+          <DashboardContent>
+            <Typography.Title level={4}>Add Sites</Typography.Title>
+            <UploadSitesForm />
+          </DashboardContent>
+          <MarginDivider />
+          <SectionHeader>Add New Site</SectionHeader>
+          <MarginBottomRow>
+            <Flex margin={'0 0 40px 0'}>
+              <Block
+                maxWidth={windowType === WindowTypes.Mobile ? '100%' : '45%'}
+              >
+                <EditSiteForm
+                  formInstance={editSiteForm}
+                  onEdit={(latLng: google.maps.LatLng) =>
+                    mapSearchMarker?.setPosition(latLng)
+                  }
+                />
+              </Block>
+              <MapTypeContext.Provider value={[mapTypeId, setMapTypeId]}>
+                <MapContainer>
+                  <SelectorMapDisplay
+                    neighborhoods={neighborhoods}
+                    sites={sites}
+                    onMove={(pos: google.maps.LatLng) => {
+                      editSiteForm.setFieldsValue({
+                        lat: round(pos.lat(), LAT_LNG_PRECISION),
+                        lng: round(pos.lng(), LAT_LNG_PRECISION),
+                      });
+                    }}
+                    setMarker={setMapSearchMarker}
+                  />
+                </MapContainer>
+              </MapTypeContext.Provider>
+            </Flex>
+            <UpdateSiteForm
+              formInstance={updateSiteForm}
+              onFinish={onSubmitAddSite}
+            />
+          </MarginBottomRow>
+        </ContentContainer>
+      </PageLayout>
+    </>
+  );
+};
+
+const mapStateToProps = (state: C4CState): AddSitesProps => {
+  return {
+    neighborhoods: state.mapGeoDataState.neighborhoodGeoData,
+    sites: state.mapGeoDataState.siteGeoData,
+  };
+};
+
+export default connect(mapStateToProps)(AddSites);

--- a/src/containers/addSites/index.tsx
+++ b/src/containers/addSites/index.tsx
@@ -105,7 +105,7 @@ const AddSites: React.FC<AddSitesProps> = ({ neighborhoods, sites }) => {
         <ContentContainer>
           <PageHeader pageTitle="Add Sites" />
           <DashboardContent>
-            <Typography.Title level={4}>Add Sites</Typography.Title>
+            <Typography.Title level={4}>Bulk Add Sites</Typography.Title>
             <UploadSitesForm />
           </DashboardContent>
           <MarginDivider />

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -83,11 +83,6 @@ const ImageLinkCard: React.FC<ImageLinkCardProps> = ({
 
 const ICON_SIZE = 40;
 
-interface AdminDashboardProps {
-  readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
-  readonly sites: MapGeoDataReducerState['siteGeoData'];
-}
-
 const AdminDashboard: React.FC = () => {
   const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) =>
     getPrivilegeLevel(state.authenticationState.tokens),

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -29,13 +29,10 @@ import {
   RocketFilled,
   SettingFilled,
 } from '@ant-design/icons';
+import Image1 from '../../assets/images/bkg1.png';
 import Image2 from '../../assets/images/bkg2.png';
-import Image3 from '../../assets/images/bkg3.png';
 import Image4 from '../../assets/images/bkg4.png';
 import { Routes } from '../../App';
-import Icon, {
-  IconComponentProps,
-} from '@ant-design/icons/lib/components/Icon';
 
 const AdminContentContainer = styled.div`
   width: 80vw;
@@ -43,7 +40,6 @@ const AdminContentContainer = styled.div`
 `;
 
 const ImageCard = styled.div`
-  background: rgba(0, 0, 0, 0.25) url(${(props) => props.background});
   background-blend-mode: darken;
   border-radius: 10px;
   width: 230px;
@@ -62,21 +58,29 @@ const ImageCard = styled.div`
   }
 `;
 
-const LargeIcon = styled((props: IconComponentProps) => <Icon {...props} />)`
-  font-size: 40px;
-`;
-
-// const AutoCompleteSelect = styled((props: SelectProps) => (
-//   <Select {...props} />
-// ))`
-//   min-width: 200px;
-//   max-width: 500px;
-// `;
-
 const AdminDivider = styled(Divider)`
   margin-top: 10px;
   margin-bottom: 20px;
 `;
+
+interface ImageLinkCardProps {
+  href: string;
+  image: string;
+}
+
+const ImageLinkCard: React.FC<ImageLinkCardProps> = ({
+  href,
+  image,
+  children,
+}) => (
+  <a href={href}>
+    <ImageCard style={{ backgroundImage: `url(${image})` }}>
+      {children}
+    </ImageCard>
+  </a>
+);
+
+const ICON_SIZE = 40;
 
 interface AdminDashboardProps {
   readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
@@ -150,24 +154,19 @@ const AdminDashboard: React.FC = () => {
           <AdminDivider />
           <Typography.Title level={3}>Admin Functions</Typography.Title>
           <Flex gap={'40px 40px'} margin={'30px 0'}>
-            <a href={Routes.ADD_SITES}>
-              <ImageCard background={Image2}>
-                <LargeIcon component={FileAddOutlined} />
-                Add Sites
-              </ImageCard>
-            </a>
-            <a href={Routes.REPORTS}>
-              <ImageCard background={Image3}>
-                <LargeIcon component={BarChartOutlined} />
-                View Reports
-              </ImageCard>
-            </a>
-            <a href={Routes.EMAIL}>
-              <ImageCard background={Image4}>
-                <LargeIcon component={MailOutlined} />
-                Email Volunteers
-              </ImageCard>
-            </a>
+            <ImageLinkCard href={Routes.ADD_SITES} image={Image1}>
+              {/* <LargeIcon component={FileAddOutlined React.ForwardRefExoticComponent<any></any>} /> */}
+              <FileAddOutlined style={{ fontSize: ICON_SIZE }} />
+              Add Sites
+            </ImageLinkCard>
+            <ImageLinkCard href={Routes.REPORTS} image={Image2}>
+              <BarChartOutlined style={{ fontSize: ICON_SIZE }} />
+              View Reports
+            </ImageLinkCard>
+            <ImageLinkCard href={Routes.EMAIL} image={Image4}>
+              <MailOutlined style={{ fontSize: ICON_SIZE }} />
+              Email Volunteers
+            </ImageLinkCard>
           </Flex>
         </AdminContentContainer>
         <Modal

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -156,7 +156,6 @@ const AdminDashboard: React.FC = () => {
           <Typography.Title level={3}>Admin Functions</Typography.Title>
           <Flex gap={'40px 40px'} margin={'30px 0'}>
             <ImageLinkCard href={Routes.ADD_SITES} image={Image1}>
-              {/* <LargeIcon component={FileAddOutlined React.ForwardRefExoticComponent<any></any>} /> */}
               <FileAddOutlined style={{ fontSize: ICON_SIZE }} />
               Add Sites
             </ImageLinkCard>

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -13,7 +13,6 @@ import {
 import { LIGHT_GREEN, MID_GREEN } from '../../utils/colors';
 import { PrivilegeLevel } from '../../auth/ducks/types';
 import ChangePrivilegeForm from '../../components/forms/changePrivilegeForm';
-import { MapGeoDataReducerState } from '../../components/mapComponents/ducks/types';
 import { Flex } from '../../components/themedComponents';
 import SignupForm from '../../components/forms/signupForm';
 import { SignupFormValues } from '../../components/forms/ducks/types';

--- a/src/containers/adminDashboard/index.tsx
+++ b/src/containers/adminDashboard/index.tsx
@@ -40,6 +40,7 @@ const AdminContentContainer = styled.div`
 `;
 
 const ImageCard = styled.div`
+  background-color: rgba(0, 0, 0, 0.25);
   background-blend-mode: darken;
   border-radius: 10px;
   width: 230px;

--- a/src/containers/email/index.tsx
+++ b/src/containers/email/index.tsx
@@ -121,9 +121,7 @@ const Email: React.FC = () => {
       </Helmet>
       <PageLayout>
         <EmailPageContainer>
-          <ReturnButton to={Routes.LANDING}>
-            {`<`} Return to Tree Map
-          </ReturnButton>
+          <ReturnButton to={Routes.ADMIN}>{`<`} Back to Dashboard</ReturnButton>
           <PageHeader pageTitle="Volunteer Emailer" />
           <Row>
             <Col span={6}>

--- a/src/containers/reports/index.tsx
+++ b/src/containers/reports/index.tsx
@@ -16,10 +16,14 @@ import {
   getCountAdoptedInPastWeek,
   getStewardshipTableReport,
 } from './ducks/selectors';
-import { PaddedPageContainer } from '../../components/themedComponents';
+import {
+  PaddedPageContainer,
+  ReturnButton,
+} from '../../components/themedComponents';
 import { CSVLink } from 'react-csv';
 import { AppError } from '../../auth/axios';
 import ExportDataForm from '../../components/forms/exportDataForm';
+import { Routes } from '../../App';
 
 const FeaturedStatsSection = styled.div`
   margin-bottom: 20px;
@@ -119,6 +123,7 @@ const Reports: React.FC = () => {
       </Helmet>
       <PageLayout>
         <PaddedPageContainer>
+          <ReturnButton to={Routes.ADMIN}>{'<'} Back to Dashboard</ReturnButton>
           <PageHeader pageTitle={t('site_report')} />
           <FeaturedStatsSection>
             <FeaturedStats


### PR DESCRIPTION
## Checklist

- [ ] 1. Run `npm run check`
- [ ] 2. Run `npm run test`
- [ ] 3. Change ClickUp ticket status to "In Review"
- [ ] 4. After making the PR, add PR link to ClickUp ticket

## Why

Redesign the admin dashboard to consolidate admin features in one page

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

- Refactors the add site forms into a new page
- Move promote user/child account form into modals within buttons
- Add links to admin features under dashboard

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

Dashboard: 

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/5ed687d9-7284-47d3-a182-8e2bba281d42)

Promote user modal:

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/a5f235f0-bbb5-4bab-b724-3f505d246881)

Child account modal:

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/48933b52-7693-4e14-a599-d59e4d264578)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
