### PR TITLE
Connect edit site entry route with frontend

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -108,6 +108,10 @@ export interface ProtectedApiClient {
     siteId: number,
     request: SiteEntriesRequest,
   ) => Promise<void>;
+  readonly editSiteEntry: (
+    entryId: number,
+    request: SiteEntriesRequest,
+  ) => Promise<void>;
   readonly getAdoptionReport: () => Promise<AdoptionReport>;
   readonly getAdoptionReportCsv: (
     previousDays: number | null,
@@ -201,6 +205,8 @@ export const ParameterizedAdminApiRoutes = {
     `/api/v1/protected/report/csv/adoption?previousDays=${previousDays}`,
   GET_STEWARDSHIP_REPORT_CSV: (previousDays: number): string =>
     `/api/v1/protected/report/csv/stewardship?previousDays=${previousDays}`,
+  EDIT_SITE_ENTRY: (entryId: number): string =>
+    `${baseSiteRoute}edit_entry/${entryId}`,
   FILTER_SITES: (params: FilterSitesParams): string =>
     `${baseSiteRoute}filter_sites?activityCountMin=${params.activityCountMin}${
       params.treeCommonNames ? `&treeCommonNames=${params.treeCommonNames}` : ''
@@ -478,6 +484,16 @@ const updateSite = (
   ).then((res) => res.data);
 };
 
+const editSiteEntry = (
+  entryId: number,
+  request: SiteEntriesRequest,
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedAdminApiRoutes.EDIT_SITE_ENTRY(entryId),
+    request,
+  ).then((res) => res.data);
+};
+
 const getAdoptionReport = (): Promise<AdoptionReport> => {
   return AppAxiosInstance.get(AdminApiClientRoutes.GET_ADOPTION_REPORT).then(
     (res) => res.data,
@@ -586,6 +602,7 @@ const Client: ProtectedApiClient = Object.freeze({
   getAdoptedSites,
   editSite,
   updateSite,
+  editSiteEntry,
   getAdoptionReport,
   getAdoptionReportCsv,
   getStewardshipReport,

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1538,6 +1538,7 @@ describe('Protected API Client Tests', () => {
 
       expect(result).toEqual(response);
     });
+
     it('makes a bad request', async () => {
       const response = 'Bad request!';
 
@@ -1546,6 +1547,112 @@ describe('Protected API Client Tests', () => {
         .reply(400, response);
 
       const result = await ProtectedApiClient.updateSite(-1, {
+        treePresent: null,
+        status: null,
+        genus: null,
+        species: null,
+        commonName: null,
+        confidence: null,
+        diameter: null,
+        circumference: null,
+        multistem: null,
+        coverage: null,
+        pruning: null,
+        condition: null,
+        discoloring: null,
+        leaning: null,
+        constrictingGrate: null,
+        wounds: null,
+        pooling: null,
+        stakesWithWires: null,
+        stakesWithoutWires: null,
+        light: null,
+        bicycle: null,
+        bagEmpty: null,
+        bagFilled: null,
+        tape: null,
+        suckerGrowth: null,
+        siteType: null,
+        sidewalkWidth: null,
+        siteWidth: null,
+        siteLength: null,
+        material: null,
+        raisedBed: null,
+        fence: null,
+        trash: null,
+        wires: null,
+        grate: null,
+        stump: null,
+        treeNotes: null,
+        siteNotes: null,
+        plantingDate: null,
+      }).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('editSiteEntry', () => {
+    it('makes the right request', async () => {
+      const response = {};
+
+      nock(BASE_URL)
+        .post(ParameterizedAdminApiRoutes.EDIT_SITE_ENTRY(-1))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.editSiteEntry(-1, {
+        treePresent: null,
+        status: null,
+        genus: null,
+        species: null,
+        commonName: null,
+        confidence: null,
+        diameter: null,
+        circumference: null,
+        multistem: null,
+        coverage: null,
+        pruning: null,
+        condition: null,
+        discoloring: null,
+        leaning: null,
+        constrictingGrate: null,
+        wounds: null,
+        pooling: null,
+        stakesWithWires: null,
+        stakesWithoutWires: null,
+        light: null,
+        bicycle: null,
+        bagEmpty: null,
+        bagFilled: null,
+        tape: null,
+        suckerGrowth: null,
+        siteType: null,
+        sidewalkWidth: null,
+        siteWidth: null,
+        siteLength: null,
+        material: null,
+        raisedBed: null,
+        fence: null,
+        trash: null,
+        wires: null,
+        grate: null,
+        stump: null,
+        treeNotes: null,
+        siteNotes: null,
+        plantingDate: null,
+      });
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request', async () => {
+      const response = 'Bad request!';
+
+      nock(BASE_URL)
+        .post(ParameterizedAdminApiRoutes.EDIT_SITE_ENTRY(-1))
+        .reply(400, response);
+
+      const result = await ProtectedApiClient.editSiteEntry(-1, {
         treePresent: null,
         status: null,
         genus: null,

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -48,14 +48,14 @@ const EntryMessage = styled(Typography.Paragraph)`
   color: ${TEXT_GREY};
 `;
 
-const EditButton = styled(Button)`
+export const EditButton = styled(Button)`
   color: ${WHITE};
   font-size: 20px;
   padding: 0px 10px;
   line-height: 0px;
 `;
 
-const StyledClose = styled(CloseOutlined)`
+export const StyledClose = styled(CloseOutlined)`
   color: ${RED};
   padding: 5px;
   border-radius: 3px;

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -7,14 +7,13 @@ import {
   LIGHT_RED,
   LIGHT_GREY,
   WHITE,
-  RED,
-  PINK,
 } from '../../utils/colors';
 import { treeCareToMoment } from '../../utils/treeFunctions';
-import { EditOutlined, DeleteOutlined, CloseOutlined } from '@ant-design/icons';
+import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { isAdmin, getUserID } from '../../auth/ducks/selectors';
 import styled from 'styled-components';
+import { EditButton, StyledClose } from '../themedComponents';
 import StewardshipForm from '../forms/stewardshipForm';
 import { LinkButton } from '../linkButton';
 import { useParams } from 'react-router-dom';
@@ -46,23 +45,6 @@ const EntryMessage = styled(Typography.Paragraph)`
   text-align: center;
   line-height: 0px;
   color: ${TEXT_GREY};
-`;
-
-export const EditButton = styled(Button)`
-  color: ${WHITE};
-  font-size: 20px;
-  padding: 0px 10px;
-  line-height: 0px;
-`;
-
-export const StyledClose = styled(CloseOutlined)`
-  color: ${RED};
-  padding: 5px;
-  border-radius: 3px;
-
-  & :hover {
-    background-color: ${PINK};
-  }
 `;
 
 const DeleteActivityButton = styled(LinkButton)`

--- a/src/components/forms/updateSiteForm/index.tsx
+++ b/src/components/forms/updateSiteForm/index.tsx
@@ -11,7 +11,6 @@ import TitleStack from '../../titleStack';
 import {
   SiteEntry,
   SiteEntryFields,
-  SiteEntryStatus,
 } from '../../../containers/treePage/ducks/types';
 import { stringNumberRules } from '../../../utils/formRules';
 import { CheckboxOptionType } from 'antd/es/checkbox/Group';
@@ -19,6 +18,7 @@ import { getSEFieldDisplayName } from '../../../utils/stringFormat';
 import { useTranslation } from 'react-i18next';
 import { n } from '../../../utils/stringFormat';
 import { site } from '../../../constants';
+import moment from 'moment';
 
 interface RadioInputProps {
   readonly name: string;
@@ -37,13 +37,13 @@ interface DateSelectorProps {
 interface UpdateSiteFormProps {
   readonly formInstance: FormInstance;
   readonly onFinish: (request: UpdateSiteRequest) => void;
-  readonly latestSiteEntry?: SiteEntry;
+  readonly initialSiteEntry?: SiteEntry;
 }
 
 const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
   formInstance,
   onFinish,
-  latestSiteEntry,
+  initialSiteEntry,
 }) => {
   const { t } = useTranslation(n(site, ['treeInfoTypes', 'forms']), {
     nsMode: 'fallback',
@@ -86,39 +86,18 @@ const UpdateSiteForm: React.FC<UpdateSiteFormProps> = ({
     );
   };
 
-  const formInitialValues = {
-    treePresent: latestSiteEntry?.treePresent ?? false,
-    multistem: latestSiteEntry?.multistem ?? false,
-    discoloring: latestSiteEntry?.discoloring ?? false,
-    leaning: latestSiteEntry?.leaning ?? false,
-    constrictingGrate: latestSiteEntry?.constrictingGrate ?? false,
-    wounds: latestSiteEntry?.wounds ?? false,
-    pooling: latestSiteEntry?.pooling ?? false,
-    stakesWithWires: latestSiteEntry?.stakesWithWires ?? false,
-    stakesWithoutWires: latestSiteEntry?.stakesWithoutWires ?? false,
-    light: latestSiteEntry?.light ?? false,
-    bicycle: latestSiteEntry?.bicycle ?? false,
-    bagEmpty: latestSiteEntry?.bagEmpty ?? false,
-    bagFilled: latestSiteEntry?.bagFilled ?? false,
-    tape: latestSiteEntry?.tape ?? false,
-    suckerGrowth: latestSiteEntry?.suckerGrowth ?? false,
-    raisedBed: latestSiteEntry?.raisedBed ?? false,
-    fence: latestSiteEntry?.fence ?? false,
-    trash: latestSiteEntry?.trash ?? false,
-    wires: latestSiteEntry?.wires ?? false,
-    grate: latestSiteEntry?.grate ?? false,
-    stump: latestSiteEntry?.stump ?? false,
-    status: latestSiteEntry?.status ?? SiteEntryStatus.ALIVE,
-    plantingDate: null,
-  };
-
   return (
     <Form
       name="basic"
       form={formInstance}
       onFinish={onFinish}
       style={{ width: '100%' }}
-      initialValues={formInitialValues}
+      initialValues={{
+        ...initialSiteEntry,
+        plantingDate: initialSiteEntry?.plantingDate
+          ? moment(initialSiteEntry?.plantingDate)
+          : null,
+      }}
     >
       <Flex>
         <TitleStack

--- a/src/components/siteEntryTable/index.tsx
+++ b/src/components/siteEntryTable/index.tsx
@@ -1,43 +1,115 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   SiteEntry,
   SiteEntryField,
   SiteEntryFields,
 } from '../../containers/treePage/ducks/types';
-import { Table } from 'antd';
+import { Form, Modal, Table, message } from 'antd';
+import { EditOutlined } from '@ant-design/icons';
+import ProtectedClient from '../../api/protectedApiClient';
 import {
   booleanToString,
   getSEFieldDisplayName,
 } from '../../utils/stringFormat';
+import { EditButton, StyledClose } from '../careEntry';
+import UpdateSiteForm from '../forms/updateSiteForm';
+import { SiteEntriesRequest, UpdateSiteRequest } from '../forms/ducks/types';
 
 interface SiteEntryTableProps {
   readonly siteEntries: SiteEntry[];
+  readonly getSite: () => void;
 }
 
-const Columns = Object.values(SiteEntryFields).map((field: SiteEntryField) => {
-  return {
-    title: getSEFieldDisplayName(field),
-    dataIndex: field,
-    key: field,
-    render: (val: string | number | boolean): string => {
-      if (val || val === false) {
-        return booleanToString(String(val));
-      } else {
-        return '';
-      }
-    },
-  };
-});
+const SiteEntryTable: React.FC<SiteEntryTableProps> = ({
+  siteEntries,
+  getSite,
+}) => {
+  const [showEditEntryModal, setShowEditEntryModal] = useState<boolean>(false);
+  const [selectedEntryId, setSelectedEntryId] = useState<number>();
 
-const SiteEntryTable: React.FC<SiteEntryTableProps> = ({ siteEntries }) => {
+  const [editSiteEntryForm] = Form.useForm();
+
+  const siteEntryTableColumns = Object.values(SiteEntryFields).map(
+    (field: SiteEntryField) => {
+      return {
+        title: getSEFieldDisplayName(field),
+        dataIndex: field,
+        key: field,
+        render: (
+          val: string | number | boolean,
+          record: SiteEntry,
+        ): string | JSX.Element => {
+          if (field !== 'editEntry') {
+            return val || val === false ? booleanToString(String(val)) : '';
+          }
+
+          return (
+            <EditButton
+              type="primary"
+              onClick={() => {
+                setShowEditEntryModal(true);
+                setSelectedEntryId(record.id);
+              }}
+            >
+              <EditOutlined />
+            </EditButton>
+          );
+        },
+      };
+    },
+  );
+
+  const onSubmitEditSiteEntry = (request: UpdateSiteRequest) => {
+    if (!selectedEntryId) {
+      return;
+    }
+
+    const entries: SiteEntriesRequest = {
+      ...request,
+      plantingDate: request.plantingDate?.format('L') || null,
+    };
+
+    ProtectedClient.editSiteEntry(selectedEntryId, entries)
+      .then(() => {
+        message.success('Site entry updated!').then();
+        setShowEditEntryModal(false);
+        getSite();
+      })
+      .catch((err) => message.error(err.response.data));
+  };
+
   return (
-    <Table
-      dataSource={siteEntries}
-      columns={Columns}
-      scroll={{ x: 1300 }}
-      rowKey={(siteEntry: SiteEntry) => siteEntry.id}
-    />
+    <>
+      <Table
+        dataSource={siteEntries}
+        columns={siteEntryTableColumns}
+        scroll={{ x: 1300 }}
+        rowKey={(siteEntry: SiteEntry) => siteEntry.id}
+      />
+
+      <Modal
+        bodyStyle={{ paddingBottom: '5px' }}
+        title={'Edit site entry'}
+        open={showEditEntryModal}
+        onCancel={() => setShowEditEntryModal(false)}
+        closeIcon={<StyledClose />}
+        footer={null}
+      >
+        <UpdateSiteForm
+          form={editSiteEntryForm}
+          onFinish={onSubmitEditSiteEntry}
+          latestSiteEntry={
+            selectedEntryId ? siteEntries[selectedEntryId] : undefined
+          }
+        />
+      </Modal>
+    </>
   );
 };
 
 export default SiteEntryTable;
+
+// TODO
+// Fix typescript error
+// Test that form works correctly
+// Provide deafult values for non-radio buttons (e.g. planting date, material in pit)

--- a/src/components/siteEntryTable/index.tsx
+++ b/src/components/siteEntryTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   SiteEntry,
   SiteEntryField,
@@ -37,15 +37,6 @@ const SiteEntryTable: React.FC<SiteEntryTableProps> = ({
 
   const [editSiteEntryForm] = Form.useForm();
 
-  useEffect(() => {
-    editSiteEntryForm.setFieldsValue({
-      ...editEntryModalData,
-      plantingDate: editEntryModalData?.plantingDate
-        ? moment(editEntryModalData?.plantingDate)
-        : null,
-    });
-  }, [editSiteEntryForm, editEntryModalData]);
-
   const siteEntryTableColumns = Object.values(SiteEntryFields).map(
     (field: SiteEntryField) => {
       return {
@@ -66,6 +57,13 @@ const SiteEntryTable: React.FC<SiteEntryTableProps> = ({
               onClick={() => {
                 setShowEditEntryModal(true);
                 setEditEntryModalData(record);
+
+                editSiteEntryForm.setFieldsValue({
+                  ...record,
+                  plantingDate: record?.plantingDate
+                    ? moment(record?.plantingDate)
+                    : null,
+                });
               }}
             >
               <EditOutlined />

--- a/src/components/siteEntryTable/index.tsx
+++ b/src/components/siteEntryTable/index.tsx
@@ -17,6 +17,7 @@ import UpdateSiteForm from '../forms/updateSiteForm';
 import { SiteEntriesRequest, UpdateSiteRequest } from '../forms/ducks/types';
 import { useTranslation } from 'react-i18next';
 import { site } from '../../constants';
+import moment from 'moment';
 
 interface SiteEntryTableProps {
   readonly siteEntries: SiteEntry[];
@@ -37,7 +38,12 @@ const SiteEntryTable: React.FC<SiteEntryTableProps> = ({
   const [editSiteEntryForm] = Form.useForm();
 
   useEffect(() => {
-    editSiteEntryForm.setFieldsValue(editEntryModalData);
+    editSiteEntryForm.setFieldsValue({
+      ...editEntryModalData,
+      plantingDate: editEntryModalData?.plantingDate
+        ? moment(editEntryModalData?.plantingDate)
+        : null,
+    });
   }, [editSiteEntryForm, editEntryModalData]);
 
   const siteEntryTableColumns = Object.values(SiteEntryFields).map(

--- a/src/components/siteEntryTable/index.tsx
+++ b/src/components/siteEntryTable/index.tsx
@@ -12,7 +12,7 @@ import {
   getSEFieldDisplayName,
   n,
 } from '../../utils/stringFormat';
-import { EditButton, StyledClose } from '../careEntry';
+import { EditButton, StyledClose } from '../themedComponents';
 import UpdateSiteForm from '../forms/updateSiteForm';
 import { SiteEntriesRequest, UpdateSiteRequest } from '../forms/ducks/types';
 import { useTranslation } from 'react-i18next';

--- a/src/components/themedComponents/index.tsx
+++ b/src/components/themedComponents/index.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from 'antd';
 import { FormItemProps } from 'antd/es/form';
+import { CloseOutlined } from '@ant-design/icons';
 import {
   BLACK,
   LIGHT_GREY,
@@ -17,6 +18,8 @@ import {
   LIGHT_GREEN,
   DARK_GREEN,
   DARK_GREY,
+  RED,
+  PINK,
 } from '../../utils/colors';
 import { LinkButton } from '../linkButton';
 import { BREAKPOINT_TABLET } from '../windowDimensions';
@@ -241,4 +244,21 @@ export const StyledSubtitle = styled(Typography.Paragraph)`
     props.isMobile ? '-20px' : '-40px'};
   color: ${(props: StyledSubtitleProps) =>
     props.subtitlecolor || { DARK_GREY }};
+`;
+
+export const EditButton = styled(Button)`
+  color: ${WHITE};
+  font-size: 20px;
+  padding: 0px 10px;
+  line-height: 0px;
+`;
+
+export const StyledClose = styled(CloseOutlined)`
+  color: ${RED};
+  padding: 5px;
+  border-radius: 3px;
+
+  & :hover {
+    background-color: ${PINK};
+  }
 `;

--- a/src/containers/sitePage/index.tsx
+++ b/src/containers/sitePage/index.tsx
@@ -151,7 +151,7 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
           </Flex>
 
           <SectionHeader strong>{t('header.site_entries')}</SectionHeader>
-          <SiteEntryTable siteEntries={site.entries} />
+          <SiteEntryTable siteEntries={site.entries} getSite={getSite} />
 
           <SectionHeader>{t('header.add_entry')}</SectionHeader>
           <MarginBottomRow>

--- a/src/containers/sitePage/index.tsx
+++ b/src/containers/sitePage/index.tsx
@@ -158,7 +158,7 @@ const SitePage: React.FC<SitePageProps> = ({ neighborhoods, sites }) => {
             <UpdateSiteForm
               formInstance={updateSiteForm}
               onFinish={onSubmitUpdateSite}
-              latestSiteEntry={
+              initialSiteEntry={
                 site.entries.length ? site.entries[0] : undefined
               }
             />

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -68,12 +68,19 @@ export enum EditableSiteEntryFields {
   PLANTING_DATE = 'plantingDate',
 }
 
+enum EditEntryField {
+  EDIT_ENTRY = 'editEntry',
+}
+
 export type SiteEntryField =
   | UneditableSiteEntryFields
-  | EditableSiteEntryFields;
+  | EditableSiteEntryFields
+  | EditEntryField;
+
 export const SiteEntryFields = {
   ...UneditableSiteEntryFields,
   ...EditableSiteEntryFields,
+  ...EditEntryField,
 };
 
 export interface SiteEntry {
@@ -188,6 +195,7 @@ export const ExtraSiteEntryNames: Record<string, string> = {
   treeNotes: t('sftt.treeNotes', { ns: 'treeInfoTypes' }),
   siteNotes: t('sftt.siteNotes', { ns: 'treeInfoTypes' }),
   plantingDate: t('sftt.plantingDate', { ns: 'treeInfoTypes' }),
+  editEntry: 'Edit Entry',
   // CAMBRIDGE
   trunks: t('cambridge.trunks', { ns: 'treeInfoTypes' }),
   speciesShort: t('cambridge.speciesShort', { ns: 'treeInfoTypes' }),

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -23,6 +23,7 @@ export interface SiteProps {
 }
 
 export enum UneditableSiteEntryFields {
+  CREATED_AT = 'createdAt',
   UPDATED_AT = 'updatedAt',
 }
 
@@ -78,13 +79,14 @@ export type SiteEntryField =
   | EditEntryField;
 
 export const SiteEntryFields = {
+  ...EditEntryField,
   ...UneditableSiteEntryFields,
   ...EditableSiteEntryFields,
-  ...EditEntryField,
 };
 
 export interface SiteEntry {
   id: number;
+  createdAt: number;
   updatedAt: number;
   status?: SiteEntryStatus;
   genus?: string;
@@ -141,7 +143,7 @@ export interface SplitSiteEntries {
 }
 
 export const MainSiteEntryNames: Record<string, string> = {
-  updatedAt: t('main.updatedAt', { ns: 'treeInfoTypes' }),
+  createdAt: t('main.createdAt', { ns: 'treeInfoTypes' }),
   status: t('main.status', { ns: 'treeInfoTypes' }),
   genus: t('main.genus', { ns: 'treeInfoTypes' }),
   species: t('main.species', { ns: 'treeInfoTypes' }),
@@ -150,7 +152,7 @@ export const MainSiteEntryNames: Record<string, string> = {
 };
 
 export const MainSiteEntryOrder: Record<string, number> = {
-  [t('main.updatedAt', { ns: 'treeInfoTypes' })]: 1,
+  [t('main.createdAt', { ns: 'treeInfoTypes' })]: 1,
   [t('main.commonName', { ns: 'treeInfoTypes' })]: 2,
   [t('main.genus', { ns: 'treeInfoTypes' })]: 3,
   [t('main.species', { ns: 'treeInfoTypes' })]: 4,
@@ -162,6 +164,7 @@ export const MainSiteEntryOrder: Record<string, number> = {
 export const ExtraSiteEntryNames: Record<string, string> = {
   // SFTT
   treePresent: t('sftt.treePresent', { ns: 'treeInfoTypes' }),
+  updatedAt: t('sftt.updatedAt', { ns: 'treeInfoTypes' }),
   confidence: t('sftt.confidence', { ns: 'treeInfoTypes' }),
   circumference: t('sftt.circumference', { ns: 'treeInfoTypes' }),
   multistem: t('sftt.multistem', { ns: 'treeInfoTypes' }),
@@ -195,7 +198,7 @@ export const ExtraSiteEntryNames: Record<string, string> = {
   treeNotes: t('sftt.treeNotes', { ns: 'treeInfoTypes' }),
   siteNotes: t('sftt.siteNotes', { ns: 'treeInfoTypes' }),
   plantingDate: t('sftt.plantingDate', { ns: 'treeInfoTypes' }),
-  editEntry: 'Edit Entry',
+  editEntry: t('sftt.editEntry', { ns: 'treeInfoTypes' }),
   // CAMBRIDGE
   trunks: t('cambridge.trunks', { ns: 'treeInfoTypes' }),
   speciesShort: t('cambridge.speciesShort', { ns: 'treeInfoTypes' }),

--- a/src/containers/treePage/test/reducers.test.ts
+++ b/src/containers/treePage/test/reducers.test.ts
@@ -31,6 +31,7 @@ describe('Tree Page Reducer', () => {
         entries: [
           {
             id: 0,
+            createdAt: 100000,
             updatedAt: 100000,
           },
         ],

--- a/src/containers/treePage/test/selectors.test.ts
+++ b/src/containers/treePage/test/selectors.test.ts
@@ -107,6 +107,7 @@ describe('Tree Page Selectors', () => {
     entries: [
       {
         id: 0,
+        createdAt: 200,
         updatedAt: 200,
         status: SiteEntryStatus.ALIVE,
         species: 'tree',
@@ -116,6 +117,7 @@ describe('Tree Page Selectors', () => {
       },
       {
         id: 1,
+        createdAt: 100,
         updatedAt: 100,
         status: SiteEntryStatus.DEAD,
         species: 'not a tree',
@@ -130,7 +132,7 @@ describe('Tree Page Selectors', () => {
       const expectedResponse: SplitSiteEntries = {
         main: [
           {
-            title: 'Updated At',
+            title: 'Created At',
             value: '200',
           },
           {
@@ -143,6 +145,10 @@ describe('Tree Page Selectors', () => {
           },
         ],
         extra: [
+          {
+            title: 'Updated At',
+            value: '200',
+          },
           {
             title: 'Circumference (inches)',
             value: '4',
@@ -177,7 +183,7 @@ describe('Tree Page Selectors', () => {
     it('returns main entries when request is completed', () => {
       const expectedMainResponse: Entry[] = [
         {
-          title: 'Updated At',
+          title: 'Created At',
           value: '200',
         },
         {
@@ -206,6 +212,10 @@ describe('Tree Page Selectors', () => {
 
     it('returns extra entries when request is completed', () => {
       const expectedExtraResponse: Entry[] = [
+        {
+          title: 'Updated At',
+          value: '200',
+        },
         {
           title: 'Circumference (inches)',
           value: '4',

--- a/src/containers/treePage/test/thunks.test.ts
+++ b/src/containers/treePage/test/thunks.test.ts
@@ -67,6 +67,7 @@ describe('Tree Page Thunks', () => {
         entries: [
           {
             id: 1,
+            createdAt: 200,
             updatedAt: 200,
             status: SiteEntryStatus.ALIVE,
             species: 'tree',
@@ -76,6 +77,7 @@ describe('Tree Page Thunks', () => {
           },
           {
             id: 2,
+            createdAt: 100,
             updatedAt: 100,
             status: SiteEntryStatus.DEAD_BUT_STANDING,
             species: 'not a tree',
@@ -188,6 +190,7 @@ describe('Tree Page Thunks', () => {
         entries: [
           {
             id: 1,
+            createdAt: 200,
             updatedAt: 200,
             status: SiteEntryStatus.ALIVE,
             species: 'tree',
@@ -197,6 +200,7 @@ describe('Tree Page Thunks', () => {
           },
           {
             id: 2,
+            createdAt: 100,
             updatedAt: 100,
             status: SiteEntryStatus.DEAD,
             species: 'not a tree',

--- a/src/i18n/en/forms.json
+++ b/src/i18n/en/forms.json
@@ -75,6 +75,10 @@
     "user_email": "User Email",
     "new_role": "New Role"
   },
+  "edit_site_entry": {
+    "success": "Site entry updated!",
+    "error": "Could not update site entry: {{error}}"
+  },
   "validation": {
     "email_required": "Please input your email!",
     "email_invalid": "Not a valid email address",

--- a/src/i18n/en/site.json
+++ b/src/i18n/en/site.json
@@ -7,5 +7,6 @@
   },
   "site_features": {
     "no_address": "No Recorded Address"
-  }
+  },
+  "edit_site_entry": "Edit site entry"
 }

--- a/src/i18n/en/treePage/types.json
+++ b/src/i18n/en/treePage/types.json
@@ -1,6 +1,6 @@
 {
   "main": {
-    "updatedAt": "Updated At",
+    "createdAt": "Created At",
     "status": "Status",
     "genus": "Genus",
     "species": "Species",
@@ -9,7 +9,9 @@
     "diameter": "Diameter at Breast Height (inches)"
   },
   "sftt": {
+    "owner": "Owner",
     "treePresent": "Is there a tree present?",
+    "updatedAt": "Updated At",
     "confidence": "Confidence",
     "circumference": "Circumference (inches)",
     "multistem": "Multistem?",
@@ -43,7 +45,7 @@
     "treeNotes": "Tree Notes",
     "siteNotes": "Site Notes",
     "plantingDate": "Date Planted",
-    "owner": "Owner"
+    "editEntry": "Edit Entry"
   },
   "cambridge": {
     "trunks": "Trunks",

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -75,14 +75,14 @@ test('booleanToString tests', () => {
 test('compareMainEntries tests', () => {
   expect(
     compareMainEntries(
-      { title: 'Updated At', value: 'test' },
+      { title: 'Created At', value: 'test' },
       { title: 'Common Name', value: 'test' },
     ),
   ).toBe(-1);
   expect(
     compareMainEntries(
       { title: 'Common Name', value: 'test' },
-      { title: 'Updated At', value: 'test' },
+      { title: 'Created At', value: 'test' },
     ),
   ).toBe(1);
   expect(
@@ -112,7 +112,7 @@ test('compareMainEntries tests', () => {
   expect(
     compareMainEntries(
       { title: 'Fake Title', value: 'test' },
-      { title: 'Updated At', value: 'test' },
+      { title: 'Created At', value: 'test' },
     ),
   ).toBe(1);
 });

--- a/src/utils/test/treeFunctions.test.ts
+++ b/src/utils/test/treeFunctions.test.ts
@@ -42,6 +42,7 @@ const testProps1: SiteProps = {
   entries: [
     {
       id: 234234,
+      createdAt: 234234,
       updatedAt: 234234,
       commonName: 'White Oak',
     },
@@ -60,6 +61,7 @@ const testProps2: SiteProps = {
   entries: [
     {
       id: 243234,
+      createdAt: 546456,
       updatedAt: 546456,
       commonName: 'Pine',
     },
@@ -78,6 +80,7 @@ const testProps3: SiteProps = {
   entries: [
     {
       id: 857435,
+      createdAt: 536436,
       updatedAt: 536436,
     },
   ],


### PR DESCRIPTION
## Checklist

- [ ] 1. Run `npm run check`
- [ ] 2. Run `npm run test`
- [ ] 3. Change ClickUp ticket status to "In Review"
- [ ] 4. After making the PR, add PR link to ClickUp ticket

## Why

[GH Projects Ticket](https://github.com/orgs/Code-4-Community/projects/15/views/1?pane=issue&itemId=29884931)

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->
Connect the edit site entry route with the frontend to allow admins to edit properties of existing site entries through the site page (http://localhost:3000/site/:site_id)

Backend PR [here](https://github.com/Code-4-Community/speak-for-the-trees-backend-v2/pull/186)

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->
Add a new column to the site entries table on the site page that admins can click to bring up a modal where they can edit an existing site entry.

While doing this, I also had to add a new column to the `SITE_ENTRIES` table, `CREATED_AT`, that keeps track of when the site entry was initially added so that the existing `UPDATED_AT` column can be used to keep track of when the site entry was updated last.

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->
Site entries table with edit entry column:
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/33704204/e892ecc2-6312-4a6e-8376-0ad3df6e5d10)

Edit entry modal:
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/33704204/eba380fa-44da-4794-bfba-bdbfbf5b6828)

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
Ensured that the modal shows up with the current site entry values and that changing some of the properties and clicking on the submit button successfully updates the site entry with the given values.
