### PR TITLE
add new stewardship activity

### DIFF
--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1347,6 +1347,7 @@ describe('Protected API Client Tests', () => {
           mulched: false,
           cleaned: true,
           weeded: false,
+          installedWateringBag: false,
         });
 
         expect(result).toEqual(response);
@@ -1365,6 +1366,7 @@ describe('Protected API Client Tests', () => {
           mulched: false,
           cleaned: false,
           weeded: false,
+          installedWateringBag: false,
         }).catch((err) => err.response.data);
 
         expect(result).toEqual(response);
@@ -1385,6 +1387,7 @@ describe('Protected API Client Tests', () => {
           mulched: false,
           cleaned: true,
           weeded: false,
+          installedWateringBag: false,
         });
 
         expect(result).toEqual(response);
@@ -1403,6 +1406,7 @@ describe('Protected API Client Tests', () => {
           mulched: false,
           cleaned: false,
           weeded: false,
+          installedWateringBag: false,
         }).catch((err) => err.response.data);
 
         expect(result).toEqual(response);
@@ -1421,6 +1425,7 @@ describe('Protected API Client Tests', () => {
           mulched: false,
           cleaned: true,
           weeded: false,
+          installedWateringBag: false,
         }).catch((err) => err.response.data);
 
         expect(result).toEqual(response);

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -118,6 +118,9 @@ const CareEntry: React.FC<CareEntryProps> = ({ activity }) => {
       weeded: values.stewardshipActivities.includes(
         t('stewardship.activities.weeded'),
       ),
+      installedWateringBag: values.stewardshipActivities.includes(
+        t('stewardship.activities.installedWateringBag'),
+      ),
     };
     protectedApiClient
       .editStewardship(activity.activityId, activities)

--- a/src/components/forms/stewardshipForm/index.tsx
+++ b/src/components/forms/stewardshipForm/index.tsx
@@ -39,6 +39,7 @@ const StewardshipForm: React.FC<StewardshipFormProps> = ({
     t('stewardship.activities.mulched'),
     t('stewardship.activities.weeded'),
     t('stewardship.activities.cleaned'),
+    t('stewardship.activities.installedWateringBag'),
   ];
 
   const disabledDate = (current: moment.Moment): boolean => {

--- a/src/containers/reports/ducks/types.ts
+++ b/src/containers/reports/ducks/types.ts
@@ -26,6 +26,7 @@ export interface StewardshipReportEntry {
   readonly mulched: boolean;
   readonly cleaned: boolean;
   readonly weeded: boolean;
+  readonly installedWateringBag: boolean;
   readonly neighborhood: string;
 }
 
@@ -46,4 +47,5 @@ export const STEWARDSHIP_REPORT_ACTIVITY_KEYS: StewardshipReportKey[] = [
   'mulched',
   'cleaned',
   'weeded',
+  'installedWateringBag',
 ];

--- a/src/containers/reports/test/selectors.test.ts
+++ b/src/containers/reports/test/selectors.test.ts
@@ -88,6 +88,7 @@ describe('Reports Selectors', () => {
             mulched: false,
             cleaned: false,
             weeded: false,
+            installedWateringBag: false,
             neighborhood: '',
           },
           {
@@ -100,6 +101,7 @@ describe('Reports Selectors', () => {
             mulched: false,
             cleaned: false,
             weeded: false,
+            installedWateringBag: false,
             neighborhood: '',
           },
           {
@@ -112,6 +114,7 @@ describe('Reports Selectors', () => {
             mulched: false,
             cleaned: true,
             weeded: false,
+            installedWateringBag: true,
             neighborhood: '',
           },
           {
@@ -124,6 +127,7 @@ describe('Reports Selectors', () => {
             mulched: true,
             cleaned: true,
             weeded: true,
+            installedWateringBag: false,
             neighborhood: '',
           },
         ],
@@ -157,7 +161,7 @@ describe('Reports Selectors', () => {
           name: '',
           email: '',
           datePerformed: new Date(2023, 3, 29),
-          activitiesPerformed: ['cleaned'],
+          activitiesPerformed: ['cleaned', 'installedWateringBag'],
           neighborhood: '',
         },
         {

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -262,6 +262,7 @@ export interface Activity {
   mulched: boolean;
   cleaned: boolean;
   weeded: boolean;
+  installedWateringBag: boolean;
 }
 
 export interface ActivityRequest extends Activity {

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -157,6 +157,9 @@ const TreePage: React.FC<TreeProps> = ({
       weeded: values.stewardshipActivities.includes(
         t('stewardship.activities.weeded'),
       ),
+      installedWateringBag: values.stewardshipActivities.includes(
+        t('stewardship.activities.installedWateringBag'),
+      ),
     };
     protectedApiClient
       .recordStewardship(id, activities)

--- a/src/containers/treePage/test/reducers.test.ts
+++ b/src/containers/treePage/test/reducers.test.ts
@@ -46,6 +46,7 @@ describe('Tree Page Reducer', () => {
             mulched: false,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 1,
@@ -55,6 +56,7 @@ describe('Tree Page Reducer', () => {
             mulched: true,
             cleaned: true,
             weeded: false,
+            installedWateringBag: false,
           },
         ],
       };

--- a/src/containers/treePage/test/selectors.test.ts
+++ b/src/containers/treePage/test/selectors.test.ts
@@ -36,6 +36,7 @@ describe('Tree Page Selectors', () => {
           mulched: true,
           cleaned: false,
           weeded: true,
+          installedWateringBag: false,
         },
         {
           id: 1,
@@ -45,6 +46,7 @@ describe('Tree Page Selectors', () => {
           mulched: false,
           cleaned: true,
           weeded: false,
+          installedWateringBag: true,
         },
       ],
     };
@@ -65,7 +67,7 @@ describe('Tree Page Selectors', () => {
           day: '23rd',
           month: 'Feb',
           year: 2021,
-          message: 'Was cleared of waste.',
+          message: 'Was cleared of waste and provided a watering bag.',
         },
       ];
 
@@ -307,6 +309,7 @@ describe('Tree Page Selectors', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 1,
@@ -316,6 +319,7 @@ describe('Tree Page Selectors', () => {
             mulched: false,
             cleaned: false,
             weeded: false,
+            installedWateringBag: false,
           },
           {
             id: 2,
@@ -325,6 +329,7 @@ describe('Tree Page Selectors', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
         ],
       };
@@ -367,6 +372,7 @@ describe('Tree Page Selectors', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 1,
@@ -376,6 +382,7 @@ describe('Tree Page Selectors', () => {
             mulched: false,
             cleaned: false,
             weeded: false,
+            installedWateringBag: false,
           },
           {
             id: 2,
@@ -385,6 +392,7 @@ describe('Tree Page Selectors', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 3,
@@ -394,6 +402,7 @@ describe('Tree Page Selectors', () => {
             mulched: true,
             cleaned: false,
             weeded: false,
+            installedWateringBag: false,
           },
         ],
       };

--- a/src/containers/treePage/test/thunks.test.ts
+++ b/src/containers/treePage/test/thunks.test.ts
@@ -42,6 +42,7 @@ describe('Tree Page Thunks', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 1,
@@ -51,6 +52,7 @@ describe('Tree Page Thunks', () => {
             mulched: false,
             cleaned: true,
             weeded: false,
+            installedWateringBag: false,
           },
         ],
       };
@@ -126,6 +128,7 @@ describe('Tree Page Thunks', () => {
             mulched: true,
             cleaned: false,
             weeded: true,
+            installedWateringBag: false,
           },
           {
             id: 1,
@@ -135,6 +138,7 @@ describe('Tree Page Thunks', () => {
             mulched: false,
             cleaned: true,
             weeded: false,
+            installedWateringBag: false,
           },
         ],
       };

--- a/src/i18n/en/forms.json
+++ b/src/i18n/en/forms.json
@@ -112,7 +112,8 @@
       "watered": "Watered",
       "mulched": "Mulched",
       "weeded": "Weeded",
-      "cleaned": "Cleared Waste & Litter"
+      "cleaned": "Cleared Waste & Litter",
+      "installedWateringBag": "Installed Watering Bag"
     },
     "date_label": "Activity Date",
     "activity_label": "Stewardship Activities"

--- a/src/i18n/en/treePage/careEntry.json
+++ b/src/i18n/en/treePage/careEntry.json
@@ -14,6 +14,7 @@
     "mulched": "mulched",
     "watered": "watered",
     "weeded": "weeded",
+    "installedWateringBag": "provided a watering bag",
     "prefix": "Was",
     "join": "and",
     "error": "At least one activity must be true"

--- a/src/utils/stringFormat.tsx
+++ b/src/utils/stringFormat.tsx
@@ -194,6 +194,10 @@ export function generateTreeCareMessage(item: Activity): string {
     activityStrings.push(t('activity_message.watered', { ns: 'careEntry' }));
   if (item.weeded)
     activityStrings.push(t('activity_message.weeded', { ns: 'careEntry' }));
+  if (item.installedWateringBag)
+    activityStrings.push(
+      t('activity_message.installedWateringBag', { ns: 'careEntry' }),
+    );
 
   const numberOfActivities = activityStrings.length;
   const prefix = t('activity_message.prefix', { ns: 'careEntry' });

--- a/src/utils/test/stringFormat.test.ts
+++ b/src/utils/test/stringFormat.test.ts
@@ -193,14 +193,18 @@ test('generateTreeCareMessage tests', () => {
       mulched: true,
       watered: true,
       weeded: true,
+      installedWateringBag: true,
     }),
-  ).toBe('Was cleared of waste, mulched, watered, and weeded.');
+  ).toBe(
+    'Was cleared of waste, mulched, watered, weeded, and provided a watering bag.',
+  );
   expect(
     generateTreeCareMessage({
       cleaned: false,
       mulched: true,
       watered: true,
       weeded: true,
+      installedWateringBag: false,
     }),
   ).toBe('Was mulched, watered, and weeded.');
   expect(
@@ -209,6 +213,7 @@ test('generateTreeCareMessage tests', () => {
       mulched: false,
       watered: false,
       weeded: true,
+      installedWateringBag: false,
     }),
   ).toBe('Was cleared of waste and weeded.');
   expect(
@@ -217,6 +222,7 @@ test('generateTreeCareMessage tests', () => {
       mulched: true,
       watered: true,
       weeded: false,
+      installedWateringBag: false,
     }),
   ).toBe('Was mulched and watered.');
   expect(
@@ -225,6 +231,7 @@ test('generateTreeCareMessage tests', () => {
       mulched: false,
       watered: false,
       weeded: false,
+      installedWateringBag: false,
     }),
   ).toBe('Was cleared of waste.');
   expect(() => {
@@ -233,6 +240,7 @@ test('generateTreeCareMessage tests', () => {
       mulched: false,
       watered: false,
       weeded: false,
+      installedWateringBag: false,
     });
   }).toThrowError(new Error('At least one activity must be true'));
 });


### PR DESCRIPTION
## Checklist

- [ ] 1. Run `npm run check`
- [ ] 2. Run `npm run test`
- [ ] 3. Change ClickUp ticket status to "In Review"
- [ ] 4. After making the PR, add PR link to ClickUp ticket

## Why

[GH Projects Ticket](https://github.com/Code-4-Community/speak-for-the-trees-frontend/issues/255)
Resolves #255 
See also https://github.com/Code-4-Community/speak-for-the-trees-backend-v2/pull/193

Add a new stewardship activity "installed watering bag" for use in the frontend

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR
- Update record/edit stewardship methods to send watering bag status
- Update `generateTreeCareMessage` to display watering bag status
- Add `installedWateringBag` field to request objects

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/27996189-1f05-4c14-bc7f-0f12d30fa6d8)
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/8a9d94fc-d69b-414e-8053-9cfbcf711c8c)
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/922946b0-f861-48b8-8daa-eb9892e7d36c)

<!-- Provide screenshots of any new components, styling changes, or pages. -->

## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->
- Verified recording/editing stewardships correctly sends watering bag status
- Verified tree page correctly displays watering bag status in stewardship message
- Verified reports correctly show watering bag status, and exported CSV contains correct watering bag status
