### PR TITLE
Ah.prevent open adoption

### DIFF
--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -180,7 +180,7 @@ const TreeInfo: React.FC<TreeProps> = ({
 
           {shareButton}
 
-          {userOwnsTree && (
+          {userOwnsTree && treePresent && (
             <StewardshipContainer>
               <Typography.Title level={3}>
                 {t('actions.record_activity')}

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -78,6 +78,7 @@ const TreeInfo: React.FC<TreeProps> = ({
   const location = useLocation<RedirectStateProps>();
 
   const isAdopted = !!siteData.entries?.[0]?.adopter;
+  const treePresent = siteData.entries[0].treePresent;
 
   const treeCommonName = getCommonName(siteData);
 
@@ -143,34 +144,38 @@ const TreeInfo: React.FC<TreeProps> = ({
 
       {loggedIn ? (
         <>
-          {userOwnsTree ? (
-            <UnadoptButton
-              danger
-              size={mobile ? 'middle' : 'large'}
-              onClick={onClickUnadopt}
-            >
-              {t('actions.unadopt')}
-            </UnadoptButton>
-          ) : (
-            <Button
-              type="primary"
-              size={mobile ? 'middle' : 'large'}
-              onClick={onClickAdopt}
-              disabled={isAdopted}
-            >
-              {isAdopted ? t('actions.adopted') : t('actions.adopt')}
-            </Button>
-          )}
+          {treePresent && (
+            <>
+              {userOwnsTree ? (
+                <UnadoptButton
+                  danger
+                  size={mobile ? 'middle' : 'large'}
+                  onClick={onClickUnadopt}
+                >
+                  {t('actions.unadopt')}
+                </UnadoptButton>
+              ) : (
+                <Button
+                  type="primary"
+                  size={mobile ? 'middle' : 'large'}
+                  onClick={onClickAdopt}
+                  disabled={isAdopted}
+                >
+                  {isAdopted ? t('actions.adopted') : t('actions.adopt')}
+                </Button>
+              )}
 
-          {userIsAdmin && (
-            <ForceUnadoptButton
-              danger
-              size={mobile ? 'middle' : 'large'}
-              onClick={onClickForceUnadopt}
-              disabled={!isAdopted}
-            >
-              {t('actions.force_unadopt')}
-            </ForceUnadoptButton>
+              {userIsAdmin && (
+                <ForceUnadoptButton
+                  danger
+                  size={mobile ? 'middle' : 'large'}
+                  onClick={onClickForceUnadopt}
+                  disabled={!isAdopted}
+                >
+                  {t('actions.force_unadopt')}
+                </ForceUnadoptButton>
+              )}
+            </>
           )}
 
           {shareButton}

--- a/src/components/treeInfo/index.tsx
+++ b/src/components/treeInfo/index.tsx
@@ -78,7 +78,7 @@ const TreeInfo: React.FC<TreeProps> = ({
   const location = useLocation<RedirectStateProps>();
 
   const isAdopted = !!siteData.entries?.[0]?.adopter;
-  const treePresent = siteData.entries[0].treePresent;
+  const treePresent = !!siteData.entries[0].treePresent;
 
   const treeCommonName = getCommonName(siteData);
 
@@ -138,6 +138,7 @@ const TreeInfo: React.FC<TreeProps> = ({
             editTreeNameForm={editTreeNameFormInstance}
             onClickEditTreeName={onClickEditTreeName}
             treeName={siteData.entries[0].treeName || ''}
+            treePresent={treePresent}
           />
         }
       </TreeHeader>

--- a/src/components/treePageHeader/index.tsx
+++ b/src/components/treePageHeader/index.tsx
@@ -26,6 +26,7 @@ interface TreePageHeaderProps extends StyledSubtitleProps {
   readonly canEditTreeName: boolean;
   readonly editTreeNameForm: FormInstance<NameSiteEntryRequest>;
   readonly onClickEditTreeName: (values: NameSiteEntryRequest) => void;
+  readonly treePresent: boolean;
 }
 
 const StyledEditOutline = styled(EditOutlined)`
@@ -56,6 +57,7 @@ const TreePageHeader: React.FC<TreePageHeaderProps> = ({
   onClickEditTreeName,
   isMobile,
   subtitlecolor,
+  treePresent,
 }) => {
   const { t } = useTranslation(n(site, ['treeInfo']), {
     nsMode: 'fallback',
@@ -80,26 +82,27 @@ const TreePageHeader: React.FC<TreePageHeaderProps> = ({
   return (
     <>
       <StyledTitle isMobile={isMobile}>{pageTitle}</StyledTitle>
-      {editingTreeName ? (
-        <EditTreeNameForm
-          editTreeNameForm={editTreeNameForm}
-          isMobile={isMobile}
-          treeName={treeName}
-          onSubmitNameChange={onTreeNameChange}
-          onCancelNameChange={() => setEditingTreeName(false)}
-        />
-      ) : (
-        <TreeNameText subtitlecolor={subtitlecolor} isMobile={isMobile}>
-          {treeDisplayName}
-          {canEditTreeName && (
-            <StyledEditOutline
-              onClick={() => {
-                setEditingTreeName(true);
-              }}
-            />
-          )}
-        </TreeNameText>
-      )}
+      {treePresent &&
+        (editingTreeName ? (
+          <EditTreeNameForm
+            editTreeNameForm={editTreeNameForm}
+            isMobile={isMobile}
+            treeName={treeName}
+            onSubmitNameChange={onTreeNameChange}
+            onCancelNameChange={() => setEditingTreeName(false)}
+          />
+        ) : (
+          <TreeNameText subtitlecolor={subtitlecolor} isMobile={isMobile}>
+            {treeDisplayName}
+            {canEditTreeName && (
+              <StyledEditOutline
+                onClick={() => {
+                  setEditingTreeName(true);
+                }}
+              />
+            )}
+          </TreeNameText>
+        ))}
       <AddressText isMobile={isMobile} subtitlecolor={subtitlecolor}>
         {pageSubtitle}
       </AddressText>


### PR DESCRIPTION
## Checklist

- [ ] 1. Run `npm run check`
- [ ] 2. Run `npm run test`
- [ ] 3. Run `npm build --if-present`  

## Why

Resolves #<Add your ticket number here>
See https://github.com/Code-4-Community/speak-for-the-trees-backend-v2/pull/196

Hide adopt buttons and stewardship form if a site does not have a tree present

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/83d5546a-b477-4f1d-8812-a471a541ba15)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->

- Verified the adopt buttons/stewardship form don't show if there is no tree present at the site
- Verified above components do show if there is a tree present