### PR TITLE
Allow users to return to map page if not logged in #236

### DIFF
--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -54,7 +54,7 @@ const NavBar: React.FC<NavBarProps> = ({ userName, isAdmin, onLogout }) => {
   } else {
     return (
       <NavContainer>
-        <NoHoverShadeButton type="text" to={Routes.HOME}>
+        <NoHoverShadeButton type="text" to={Routes.LANDING}>
           <MainLogo src={SFTT_PARTNER_LOGOS} alt={'SFTT Logo'} />
         </NoHoverShadeButton>
         <NavExtra


### PR DESCRIPTION
Todo: look into routing to HOME when not on sign up or login

## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #236 

This ticket resolves being able to move to the map page when users are not signed it. Previously, the SFTT logo in the NavBar redirected users to the home page, which we are in progress to remove. Additionally, when users are not signed in, a redirect to the home page would redirect to login/signup. As such, there was no clear path to the landing map page from login/signup.

## This PR

This change allows the SFTT logo to be used as a redirect and bring users straight to the map page. We changed the NavBar SFTT Logo redirect from Routes.HOME to Routes.LANDING. Note that this change affects all pages (not just sign up and login), and that the HOME page is being deprecated.

## Screenshots

https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/2d96d761-cf49-4821-b354-872f05faeac2

https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/5c5a84a8-61a0-4149-bbd3-a7ce98ac9212


## Verification Steps

To verify that this worked we tested that users, signed in and not signed in, are directed to the landing map page when clicking the SFTT logo.

