### PR TITLE
Site Image Deletion

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -127,6 +127,9 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly addSites: (request: AddSitesRequest) => Promise<void>;
   readonly sendEmail: (request: SendEmailRequest) => Promise<void>;
+  readonly deleteImage: (
+      imageId: number,
+  ) => Promise<void>;
   readonly filterSites: (
     params: FilterSitesParams,
   ) => Promise<FilterSitesResponse>;
@@ -197,6 +200,8 @@ export const ParameterizedApiRoutes = {
   UPDATE_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/update`,
   NAME_SITE_ENTRY: (siteId: number): string =>
     `${baseSiteRoute}${siteId}/name_entry`,
+  DELETE_IMAGE: (imageId: number): string =>
+      `${baseSiteRoute}site_image/${imageId}`,
 };
 
 export const ParameterizedAdminApiRoutes = {
@@ -556,6 +561,12 @@ const sendEmail = (request: SendEmailRequest): Promise<void> => {
   );
 };
 
+const deleteImage = (imageId: number): Promise<void> => {
+  return AppAxiosInstance.delete(
+    ParameterizedApiRoutes.DELETE_IMAGE(imageId),
+  ).then((res) => res.data);
+};
+
 const filterSites = (
   params: FilterSitesParams,
 ): Promise<FilterSitesResponse> => {
@@ -611,6 +622,7 @@ const Client: ProtectedApiClient = Object.freeze({
   nameSiteEntry,
   addSites,
   sendEmail,
+  deleteImage,
   filterSites,
 });
 

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -127,9 +127,7 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly addSites: (request: AddSitesRequest) => Promise<void>;
   readonly sendEmail: (request: SendEmailRequest) => Promise<void>;
-  readonly deleteImage: (
-      imageId: number,
-  ) => Promise<void>;
+  readonly deleteImage: (imageId: number) => Promise<void>;
   readonly filterSites: (
     params: FilterSitesParams,
   ) => Promise<FilterSitesResponse>;
@@ -201,7 +199,7 @@ export const ParameterizedApiRoutes = {
   NAME_SITE_ENTRY: (siteId: number): string =>
     `${baseSiteRoute}${siteId}/name_entry`,
   DELETE_IMAGE: (imageId: number): string =>
-      `${baseSiteRoute}site_image/${imageId}`,
+    `${baseSiteRoute}site_image/${imageId}`,
 };
 
 export const ParameterizedAdminApiRoutes = {

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { TreeCare } from '../../containers/treePage/ducks/types';
-import { Row, Col, Typography, Button, Form, Modal, message } from 'antd';
+import { Row, Col, Typography, Form, Modal, message } from 'antd';
 import {
   DARK_GREEN,
   TEXT_GREY,
@@ -13,7 +13,11 @@ import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { isAdmin, getUserID } from '../../auth/ducks/selectors';
 import styled from 'styled-components';
-import { EditButton, StyledClose } from '../themedComponents';
+import {
+  ConfirmDeleteButton,
+  EditButton,
+  StyledClose,
+} from '../themedComponents';
 import StewardshipForm from '../forms/stewardshipForm';
 import { LinkButton } from '../linkButton';
 import { useParams } from 'react-router-dom';
@@ -26,6 +30,7 @@ import { C4CState } from '../../store';
 import { useTranslation } from 'react-i18next';
 import { site } from '../../constants';
 import { n } from '../../utils/stringFormat';
+import ConfirmationModel from '../confirmationModal';
 
 const Entry = styled.div`
   margin: 15px;
@@ -56,15 +61,6 @@ export const DeleteActivityButton = styled(LinkButton)`
 
   & :hover {
     color: ${LIGHT_RED};
-    background-color: ${LIGHT_GREY};
-  }
-`;
-
-export const ConfirmDelete = styled(Button)`
-  margin: 10px;
-  padding-left: 10px;
-
-  & :hover {
     background-color: ${LIGHT_GREY};
   }
 `;
@@ -184,19 +180,14 @@ const CareEntry: React.FC<CareEntryProps> = ({ activity }) => {
           initialDate={treeCareToMoment(activity)}
         />
       </Modal>
-      <Modal
-        title={t('delete_title')}
+      <ConfirmationModel
         visible={showDeleteForm}
         onOk={() => setShowDeleteForm(false)}
         onCancel={() => setShowDeleteForm(false)}
-        footer={null}
-        closeIcon={<StyledClose />}
-      >
-        <p>{t('delete_message')}</p>
-        <ConfirmDelete onClick={onClickDeleteActivity}>
-          {t('delete')}
-        </ConfirmDelete>
-      </Modal>
+        title={t('delete_title')}
+        confirmationMessage={t('delete_message')}
+        onConfirm={onClickDeleteActivity}
+      />
     </>
   );
 };

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -14,7 +14,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { isAdmin, getUserID } from '../../auth/ducks/selectors';
 import styled from 'styled-components';
 import {
-  ConfirmDeleteButton,
   EditButton,
   StyledClose,
 } from '../themedComponents';
@@ -52,7 +51,7 @@ const EntryMessage = styled(Typography.Paragraph)`
   color: ${TEXT_GREY};
 `;
 
-export const DeleteActivityButton = styled(LinkButton)`
+const DeleteActivityButton = styled(LinkButton)`
   color: ${WHITE};
   margin: 10px;
   padding: 0px 10px;

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -47,7 +47,7 @@ const EntryMessage = styled(Typography.Paragraph)`
   color: ${TEXT_GREY};
 `;
 
-const DeleteActivityButton = styled(LinkButton)`
+export const DeleteActivityButton = styled(LinkButton)`
   color: ${WHITE};
   margin: 10px;
   padding: 0px 10px;
@@ -60,7 +60,7 @@ const DeleteActivityButton = styled(LinkButton)`
   }
 `;
 
-const ConfirmDelete = styled(Button)`
+export const ConfirmDelete = styled(Button)`
   margin: 10px;
   padding-left: 10px;
 

--- a/src/components/confirmationModal/index.tsx
+++ b/src/components/confirmationModal/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, Modal } from 'antd';
+import { StyledClose } from '../themedComponents';
+import styled from 'styled-components';
+import { LIGHT_GREY } from '../../utils/colors';
+
+const ConfirmDeleteButton = styled(Button)`
+  margin: 10px;
+  padding-left: 10px;
+
+  & :hover {
+    background-color: ${LIGHT_GREY};
+  }
+`;
+
+interface ConfirmationModelProps {
+  visible: boolean;
+  onOk: () => void;
+  onCancel: () => void;
+  title: string;
+  confirmationMessage: string;
+  onConfirm: () => void;
+}
+
+const ConfirmationModel: React.FC<ConfirmationModelProps> = ({
+  visible,
+  onOk,
+  onCancel,
+  confirmationMessage,
+  title,
+  onConfirm,
+}) => {
+  return (
+    <>
+      <Modal
+        title={title}
+        visible={visible}
+        onOk={onOk}
+        onCancel={onCancel}
+        footer={null}
+        closeIcon={<StyledClose />}
+      >
+        <p>{confirmationMessage}</p>
+        <ConfirmDeleteButton onClick={onConfirm}>Delete</ConfirmDeleteButton>
+      </Modal>
+    </>
+  );
+};
+
+export default ConfirmationModel;

--- a/src/components/themedComponents/index.tsx
+++ b/src/components/themedComponents/index.tsx
@@ -138,6 +138,15 @@ export const MenuLinkButton = styled(LinkButton)`
   text-align: left;
 `;
 
+export const ConfirmDeleteButton = styled(Button)`
+  margin: 10px;
+  padding-left: 10px;
+
+  & :hover {
+    background-color: ${LIGHT_GREY};
+  }
+`;
+
 export const MainContent = styled.div`
   height: 100%;
 `;

--- a/src/components/treePage/siteImageCarousel.tsx
+++ b/src/components/treePage/siteImageCarousel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Carousel, message, Modal, Space } from 'antd';
+import { Carousel, message, Modal, Space } from 'antd';
 import LeftOutlined from '@ant-design/icons/lib/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/lib/icons/RightOutlined';
 import { useSelector } from 'react-redux';
@@ -10,12 +10,10 @@ import { getLatestEntrySiteImages } from '../../containers/treePage/ducks/select
 import { C4CState } from '../../store';
 import { n } from '../../utils/stringFormat';
 import { site } from '../../constants';
-import { ConfirmDelete } from '../careEntry';
-// import { DeleteOutlined } from '@ant-design/icons';
-// import {GreenButton, StyledClose} from '../themedComponents';
 import { LinkButton } from '../linkButton';
 import { LIGHT_GREY, LIGHT_RED, WHITE } from '../../utils/colors';
 import protectedApiClient from '../../api/protectedApiClient';
+import ConfirmationModel from '../confirmationModal';
 
 const CarouselContainer = styled.div`
   margin-top: 20px;
@@ -57,15 +55,15 @@ const FooterContainer = styled.div`
 `;
 
 export const DeleteSiteImageButton = styled(LinkButton)`
-  color: ${LIGHT_RED};
+  color: ${WHITE};
   margin: 10px;
   padding: 0px 10px;
+  background: ${LIGHT_RED};
   border: none;
-  background-color: ${LIGHT_GREY};
 
   & :hover {
-    color: ${LIGHT_GREY};
-    background-color: ${LIGHT_RED};
+    color: ${LIGHT_RED};
+    background-color: ${LIGHT_GREY};
   }
 `;
 
@@ -105,6 +103,7 @@ export const SiteImageCarousel: React.FC = () => {
               </div>
             ))}
           </StyledCarousel>
+
           <FooterContainer>
             <div>
               {t('site_image.uploaded_by', {
@@ -117,7 +116,6 @@ export const SiteImageCarousel: React.FC = () => {
               <div>
                 {latestEntrySiteImages[currSlideIndex].uploadedAt ||
                   t('site_image.no_upload_date')}
-                {/*<td width="20%"></td>*/}
               </div>
               <div>
                 <DeleteSiteImageButton
@@ -125,30 +123,20 @@ export const SiteImageCarousel: React.FC = () => {
                   onClick={() => setShowDeleteForm(!showDeleteForm)}
                 >
                   Delete
-                  {/*<DeleteOutlined />*/}
                 </DeleteSiteImageButton>
               </div>
             </Space>
           </FooterContainer>
-          <Modal
-            title="Delete Site Image"
+          <ConfirmationModel
             visible={showDeleteForm}
             onOk={() => setShowDeleteForm(false)}
             onCancel={() => setShowDeleteForm(false)}
-            footer={null}
-            // closeIcon={<StyledClose />}
-          >
-            <p>Are you sure you want to delete this image?</p>
-            <ConfirmDelete
-              onClick={() =>
-                onClickDeleteImage(
-                  latestEntrySiteImages[currSlideIndex].imageId,
-                )
-              }
-            >
-              Delete
-            </ConfirmDelete>
-          </Modal>
+            title="Delete Site Image"
+            confirmationMessage="Are you sure you want to delete this image?"
+            onConfirm={() =>
+              onClickDeleteImage(latestEntrySiteImages[currSlideIndex].imageId)
+            }
+          />
         </CarouselContainer>
       )}
     </>

--- a/src/components/treePage/siteImageCarousel.tsx
+++ b/src/components/treePage/siteImageCarousel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Carousel } from 'antd';
+import {Button, Carousel, message, Modal, Space} from 'antd';
 import LeftOutlined from '@ant-design/icons/lib/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/lib/icons/RightOutlined';
 import { useSelector } from 'react-redux';
@@ -10,6 +10,13 @@ import { getLatestEntrySiteImages } from '../../containers/treePage/ducks/select
 import { C4CState } from '../../store';
 import { n } from '../../utils/stringFormat';
 import { site } from '../../constants';
+import { ConfirmDelete } from '../careEntry';
+// import { DeleteOutlined } from '@ant-design/icons';
+// import {GreenButton, StyledClose} from '../themedComponents';
+import { LinkButton } from '../linkButton';
+import { LIGHT_GREY, LIGHT_RED, WHITE } from '../../utils/colors';
+import protectedApiClient from "../../api/protectedApiClient";
+import {getSiteData} from "../../containers/treePage/ducks/thunks";
 
 const CarouselContainer = styled.div`
   margin-top: 20px;
@@ -50,8 +57,27 @@ const FooterContainer = styled.div`
   margin-top: 10px;
 `;
 
+export const DeleteSiteImageButton = styled(LinkButton)`
+  color: ${LIGHT_RED};
+  margin: 10px;
+  padding: 0px 10px;
+  border: none;
+  background-color: ${LIGHT_GREY};
+
+  & :hover {
+    color: ${LIGHT_GREY};
+    background-color: ${LIGHT_RED};
+  }
+`;
+
+function onClickDeleteImage() {
+  protectedApiClient.delete
+}
+
 export const SiteImageCarousel: React.FC = () => {
   const { t } = useTranslation(n(site, 'treePage'), { nsMode: 'fallback' });
+
+  const [showDeleteForm, setShowDeleteForm] = useState<boolean>(false);
 
   const latestEntrySiteImages = useSelector((state: C4CState) => {
     return getLatestEntrySiteImages(state.siteState.siteData);
@@ -78,7 +104,6 @@ export const SiteImageCarousel: React.FC = () => {
               </div>
             ))}
           </StyledCarousel>
-
           <FooterContainer>
             <div>
               {t('site_image.uploaded_by', {
@@ -87,13 +112,36 @@ export const SiteImageCarousel: React.FC = () => {
                   'Anonymous',
               })}
             </div>
-            <div>
-              {latestEntrySiteImages[currSlideIndex].uploadedAt ||
-                t('site_image.no_upload_date')}
-            </div>
+            <Space size={15}>
+              <div>
+                {latestEntrySiteImages[currSlideIndex].uploadedAt ||
+                  t('site_image.no_upload_date')}
+                {/*<td width="20%"></td>*/}
+              </div>
+              <div>
+                <DeleteSiteImageButton
+                  type="primary"
+                  onClick={() => setShowDeleteForm(!showDeleteForm)}
+                >
+                  Delete
+                  {/*<DeleteOutlined />*/}
+                </DeleteSiteImageButton>
+              </div>
+            </Space>
           </FooterContainer>
         </CarouselContainer>
       )}
+      <Modal
+        title="Delete Site Image"
+        visible={showDeleteForm}
+        onOk={() => setShowDeleteForm(false)}
+        onCancel={() => setShowDeleteForm(false)}
+        footer={null}
+        // closeIcon={<StyledClose />}
+      >
+        <p>Are you sure you want to delete this image?</p>
+        <ConfirmDelete onClick={onClickDeleteImage}>Delete</ConfirmDelete>
+      </Modal>
     </>
   );
 };

--- a/src/components/treePage/siteImageCarousel.tsx
+++ b/src/components/treePage/siteImageCarousel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import {Button, Carousel, message, Modal, Space} from 'antd';
+import { Button, Carousel, message, Modal, Space } from 'antd';
 import LeftOutlined from '@ant-design/icons/lib/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/lib/icons/RightOutlined';
 import { useSelector } from 'react-redux';
@@ -15,8 +15,7 @@ import { ConfirmDelete } from '../careEntry';
 // import {GreenButton, StyledClose} from '../themedComponents';
 import { LinkButton } from '../linkButton';
 import { LIGHT_GREY, LIGHT_RED, WHITE } from '../../utils/colors';
-import protectedApiClient from "../../api/protectedApiClient";
-import {getSiteData} from "../../containers/treePage/ducks/thunks";
+import protectedApiClient from '../../api/protectedApiClient';
 
 const CarouselContainer = styled.div`
   margin-top: 20px;
@@ -69,8 +68,6 @@ export const DeleteSiteImageButton = styled(LinkButton)`
     background-color: ${LIGHT_RED};
   }
 `;
-
-
 
 export const SiteImageCarousel: React.FC = () => {
   const { t } = useTranslation(n(site, 'treePage'), { nsMode: 'fallback' });
@@ -143,7 +140,14 @@ export const SiteImageCarousel: React.FC = () => {
           >
             <p>Are you sure you want to delete this image?</p>
             <ConfirmDelete
-                onClick={() => onClickDeleteImage(latestEntrySiteImages[currSlideIndex].imageId)}>Delete</ConfirmDelete>
+              onClick={() =>
+                onClickDeleteImage(
+                  latestEntrySiteImages[currSlideIndex].imageId,
+                )
+              }
+            >
+              Delete
+            </ConfirmDelete>
           </Modal>
         </CarouselContainer>
       )}

--- a/src/components/treePage/siteImageCarousel.tsx
+++ b/src/components/treePage/siteImageCarousel.tsx
@@ -70,9 +70,7 @@ export const DeleteSiteImageButton = styled(LinkButton)`
   }
 `;
 
-function onClickDeleteImage() {
-  protectedApiClient.delete
-}
+
 
 export const SiteImageCarousel: React.FC = () => {
   const { t } = useTranslation(n(site, 'treePage'), { nsMode: 'fallback' });
@@ -87,6 +85,12 @@ export const SiteImageCarousel: React.FC = () => {
 
   const onAfterChange = (currentSlide: number) =>
     setCurrSlideIndex(currentSlide);
+  function onClickDeleteImage(imageId: number) {
+    protectedApiClient.deleteImage(imageId).then((ok) => {
+      message.success('success');
+      setShowDeleteForm(false);
+    });
+  }
 
   return (
     <>
@@ -129,19 +133,20 @@ export const SiteImageCarousel: React.FC = () => {
               </div>
             </Space>
           </FooterContainer>
+          <Modal
+            title="Delete Site Image"
+            visible={showDeleteForm}
+            onOk={() => setShowDeleteForm(false)}
+            onCancel={() => setShowDeleteForm(false)}
+            footer={null}
+            // closeIcon={<StyledClose />}
+          >
+            <p>Are you sure you want to delete this image?</p>
+            <ConfirmDelete
+                onClick={() => onClickDeleteImage(latestEntrySiteImages[currSlideIndex].imageId)}>Delete</ConfirmDelete>
+          </Modal>
         </CarouselContainer>
       )}
-      <Modal
-        title="Delete Site Image"
-        visible={showDeleteForm}
-        onOk={() => setShowDeleteForm(false)}
-        onCancel={() => setShowDeleteForm(false)}
-        footer={null}
-        // closeIcon={<StyledClose />}
-      >
-        <p>Are you sure you want to delete this image?</p>
-        <ConfirmDelete onClick={onClickDeleteImage}>Delete</ConfirmDelete>
-      </Modal>
     </>
   );
 };

--- a/src/components/treePage/siteImageCarousel.tsx
+++ b/src/components/treePage/siteImageCarousel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Carousel, message, Modal, Space } from 'antd';
+import { Carousel, message, Space } from 'antd';
 import LeftOutlined from '@ant-design/icons/lib/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/lib/icons/RightOutlined';
 import { useSelector } from 'react-redux';
@@ -103,6 +103,7 @@ export const SiteImageCarousel: React.FC = () => {
               </div>
             ))}
           </StyledCarousel>
+
           <FooterContainer>
             <div>
               {t('site_image.uploaded_by', {


### PR DESCRIPTION
## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #288 

This ticket adds the delete button to site images, allowing users to delete uploaded images. This keeps our site clean, to avoid irrelevant and incorrect images from staying online.

## This PR

This change both adds delete functionality to the client, but adds a UI component to actually add an image. This deletion occurs both in AWS and the database (as dictated by the backend)

## Screenshots
<img width="658" alt="Screen Shot 2023-11-12 at 2 45 50 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/565360af-49db-4bd3-ac7c-e4f184bf4c89">

## Verification Steps

We manually tested this by:
- Uploading an image on the branch SK.CL.upload-site-image
- Opening AWS > sftt-user-uploads > ... > image folder, ensuring that the image exists
- Clicking the delete button
- Checking that AWS no longer had the image
- Checking that the database site_images folder no longer contains the image