### PR TITLE
Move delete site image functionality to clean branch

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -127,6 +127,7 @@ export interface ProtectedApiClient {
   ) => Promise<void>;
   readonly addSites: (request: AddSitesRequest) => Promise<void>;
   readonly sendEmail: (request: SendEmailRequest) => Promise<void>;
+  readonly deleteImage: (imageId: number) => Promise<void>;
   readonly filterSites: (
     params: FilterSitesParams,
   ) => Promise<FilterSitesResponse>;
@@ -197,6 +198,8 @@ export const ParameterizedApiRoutes = {
   UPDATE_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/update`,
   NAME_SITE_ENTRY: (siteId: number): string =>
     `${baseSiteRoute}${siteId}/name_entry`,
+  DELETE_IMAGE: (imageId: number): string =>
+    `${baseSiteRoute}site_image/${imageId}`,
 };
 
 export const ParameterizedAdminApiRoutes = {
@@ -556,6 +559,12 @@ const sendEmail = (request: SendEmailRequest): Promise<void> => {
   );
 };
 
+const deleteImage = (imageId: number): Promise<void> => {
+  return AppAxiosInstance.delete(
+    ParameterizedApiRoutes.DELETE_IMAGE(imageId),
+  ).then((res) => res.data);
+};
+
 const filterSites = (
   params: FilterSitesParams,
 ): Promise<FilterSitesResponse> => {
@@ -611,6 +620,7 @@ const Client: ProtectedApiClient = Object.freeze({
   nameSiteEntry,
   addSites,
   sendEmail,
+  deleteImage,
   filterSites,
 });
 

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -1489,6 +1489,33 @@ describe('Protected API Client Tests', () => {
         expect(result).toEqual(response);
       });
     });
+
+    describe('deleteSiteImage', () => {
+      it('makes the right request', async () => {
+        const response = 'Image Deleted Correctly';
+
+        nock(BASE_URL)
+          .delete(ParameterizedApiRoutes.DELETE_IMAGE(1))
+          .reply(200, response);
+
+        const result = await ProtectedApiClient.deleteImage(1);
+
+        expect(result).toEqual(response);
+      });
+      it('makes a bad request', async () => {
+        const response = 'Invalid Image ID';
+
+        nock(BASE_URL)
+          .delete(ParameterizedApiRoutes.DELETE_IMAGE(-1))
+          .reply(400, response);
+
+        const result = await ProtectedApiClient.deleteImage(-1).catch(
+          (err) => err.response.data,
+        );
+
+        expect(result).toEqual(response);
+      });
+    });
   });
 
   describe('updateSite', () => {

--- a/src/components/careEntry/index.tsx
+++ b/src/components/careEntry/index.tsx
@@ -26,6 +26,7 @@ import { C4CState } from '../../store';
 import { useTranslation } from 'react-i18next';
 import { site } from '../../constants';
 import { n } from '../../utils/stringFormat';
+import ConfirmationModal from '../confirmationModal';
 
 const Entry = styled.div`
   margin: 15px;
@@ -56,15 +57,6 @@ const DeleteActivityButton = styled(LinkButton)`
 
   & :hover {
     color: ${LIGHT_RED};
-    background-color: ${LIGHT_GREY};
-  }
-`;
-
-const ConfirmDelete = styled(Button)`
-  margin: 10px;
-  padding-left: 10px;
-
-  & :hover {
     background-color: ${LIGHT_GREY};
   }
 `;
@@ -184,19 +176,14 @@ const CareEntry: React.FC<CareEntryProps> = ({ activity }) => {
           initialDate={treeCareToMoment(activity)}
         />
       </Modal>
-      <Modal
-        title={t('delete_title')}
+      <ConfirmationModal
         visible={showDeleteForm}
         onOk={() => setShowDeleteForm(false)}
         onCancel={() => setShowDeleteForm(false)}
-        footer={null}
-        closeIcon={<StyledClose />}
-      >
-        <p>{t('delete_message')}</p>
-        <ConfirmDelete onClick={onClickDeleteActivity}>
-          {t('delete')}
-        </ConfirmDelete>
-      </Modal>
+        title={t('delete_title')}
+        confirmationMessage={t('delete_message')}
+        onConfirm={onClickDeleteActivity}
+      />
     </>
   );
 };

--- a/src/components/confirmationModal/index.tsx
+++ b/src/components/confirmationModal/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Button, Modal } from 'antd';
+import { StyledClose } from '../themedComponents';
+import styled from 'styled-components';
+import { LIGHT_GREY } from '../../utils/colors';
+
+const ConfirmDeleteButton = styled(Button)`
+  margin: 10px;
+  padding-left: 10px;
+
+  & :hover {
+    background-color: ${LIGHT_GREY};
+  }
+`;
+
+interface ConfirmationModalProps {
+  visible: boolean;
+  onOk: () => void;
+  onCancel: () => void;
+  title: string;
+  confirmationMessage: string;
+  onConfirm: () => void;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  visible,
+  onOk,
+  onCancel,
+  confirmationMessage,
+  title,
+  onConfirm,
+}) => {
+  return (
+    <>
+      <Modal
+        title={title}
+        visible={visible}
+        onOk={onOk}
+        onCancel={onCancel}
+        footer={null}
+        closeIcon={<StyledClose />}
+      >
+        <p>{confirmationMessage}</p>
+        <ConfirmDeleteButton onClick={onConfirm}>Delete</ConfirmDeleteButton>
+      </Modal>
+    </>
+  );
+};
+
+export default ConfirmationModal;

--- a/src/components/themedComponents/index.tsx
+++ b/src/components/themedComponents/index.tsx
@@ -138,6 +138,14 @@ export const MenuLinkButton = styled(LinkButton)`
   text-align: left;
 `;
 
+export const ConfirmDeleteButton = styled(Button)`
+  margin: 10px;
+  padding-left: 10px;
+  & :hover {
+    background-color: ${LIGHT_GREY};
+  }
+`;
+
 export const MainContent = styled.div`
   height: 100%;
 `;

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -295,6 +295,7 @@ export interface SiteEntryImage {
   uploaderUsername: string;
   uploadedAt: string;
   imageUrl: string;
+  uploaderId: number;
 }
 
 export interface TreeBenefits {

--- a/src/containers/treePage/test/selectors.test.ts
+++ b/src/containers/treePage/test/selectors.test.ts
@@ -124,12 +124,14 @@ describe('Tree Page Selectors', () => {
             imageUrl: 'http://www.some-address.com',
             uploadedAt: '09/06/2023',
             uploaderUsername: 'First Last',
+            uploaderId: 1,
           },
           {
             imageId: 2,
             imageUrl: 'http://www.some-other-address.com',
             uploadedAt: '01/01/2023',
             uploaderUsername: 'Hello World',
+            uploaderId: 2,
           },
         ],
       },
@@ -147,6 +149,7 @@ describe('Tree Page Selectors', () => {
             imageUrl: 'http://www.should-not-be-returned.com',
             uploadedAt: '01/01/2022',
             uploaderUsername: 'Code4Community',
+            uploaderId: 1,
           },
         ],
       },
@@ -281,12 +284,14 @@ describe('Tree Page Selectors', () => {
           imageUrl: 'http://www.some-address.com',
           uploadedAt: '09/06/2023',
           uploaderUsername: 'First Last',
+          uploaderId: 1,
         },
         {
           imageId: 2,
           imageUrl: 'http://www.some-other-address.com',
           uploadedAt: '01/01/2023',
           uploaderUsername: 'Hello World',
+          uploaderId: 2,
         },
       ];
 


### PR DESCRIPTION
This is a duplicate of https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/303 to fix build issues

## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #288 

This ticket adds the delete button to site images, allowing users to delete uploaded images. This keeps our site clean, to avoid irrelevant and incorrect images from staying online.

## This PR

This change both adds delete functionality to the client, but adds a UI component to actually add an image. This deletion occurs both in AWS and the database (as dictated by the backend)

## Screenshots
<img width="658" alt="Screen Shot 2023-11-12 at 2 45 50 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/565360af-49db-4bd3-ac7c-e4f184bf4c89">

## Verification Steps

We manually tested this by:
- Uploading an image on the branch SK.CL.upload-site-image
- Opening AWS > sftt-user-uploads > ... > image folder, ensuring that the image exists
- Clicking the delete button
- Checking that AWS no longer had the image
- Checking that the database site_images folder no longer contains the image