### PR TITLE
Ot.language options

### DIFF
--- a/src/components/navBar/mobileNavBar/index.tsx
+++ b/src/components/navBar/mobileNavBar/index.tsx
@@ -9,6 +9,8 @@ import { MID_GREEN, BACKGROUND_GREY, LIGHT_GREEN } from '../../../utils/colors';
 import Logo from '../../../assets/images/nav-bar-icon.png';
 import NavMenu from '../navMenu';
 import { LinkButton } from '../../linkButton';
+import TranslationDropdown from '../translationDropdown';
+import { Flex } from '../../themedComponents';
 
 interface MobileNavBarProps {
   readonly isLoggedIn: boolean;
@@ -28,10 +30,6 @@ const MobileNavHeader: typeof PageHeader = styled(PageHeader)<PageHeaderProps>`
   background: ${BACKGROUND_GREY};
   color: ${MID_GREEN};
   font-weight: 700;
-`;
-
-const FlexDiv = styled.div`
-  display: flex;
 `;
 
 const SignUpButton = styled(LinkButton)`
@@ -66,23 +64,27 @@ const MobileNavBar: React.FC<MobileNavBarProps> = ({
       onBack={() => history.push(Routes.LANDING)}
       extra={
         isLoggedIn ? (
-          <FlexDiv>
+          <Flex gap="2vw">
+            <TranslationDropdown />
             <Dropdown
               overlay={<NavMenu isAdmin={isAdmin} onLogout={onLogout} />}
               placement="bottomLeft"
             >
               <MobileDropdownMenu />
             </Dropdown>
-          </FlexDiv>
+          </Flex>
         ) : (
-          <SignUpButton
-            type="primary"
-            htmlType="submit"
-            size="large"
-            to={Routes.SIGNUP}
-          >
-            Sign Up
-          </SignUpButton>
+          <Flex gap="2vw">
+            <TranslationDropdown />
+            <SignUpButton
+              type="primary"
+              htmlType="submit"
+              size="large"
+              to={Routes.SIGNUP}
+            >
+              Sign Up
+            </SignUpButton>
+          </Flex>
         )
       }
     />

--- a/src/components/navBar/navExtra/index.tsx
+++ b/src/components/navBar/navExtra/index.tsx
@@ -6,7 +6,7 @@ import { UserOutlined } from '@ant-design/icons';
 import { BLACK, DARK_GREEN, LIGHT_GREEN, WHITE } from '../../../utils/colors';
 import NavMenu from '../navMenu';
 import { Location } from 'history';
-import { GreenLinkButton } from '../../themedComponents';
+import { Flex, GreenLinkButton } from '../../themedComponents';
 import TranslationDropdown from '../translationDropdown';
 
 const FlexDiv = styled.div`
@@ -15,17 +15,11 @@ const FlexDiv = styled.div`
   margin-right: 20px;
   height: 100%;
   line-height: 9vh;
-`;
-
-const LandingExtraContainer = styled.div`
-  float: right;
-  padding-right: 2vw;
-  padding-top: 22px;
-  height: 100%;
+  gap: 2vw;
+  align-items: center;
 `;
 
 const SignupButton = styled(GreenLinkButton)`
-  margin-right: 2vw;
   background-color: ${LIGHT_GREEN},
   border-color: ${LIGHT_GREEN};
 `;
@@ -76,7 +70,7 @@ const NavExtra: React.FC<NavExtraProps> = ({
     );
   } else {
     return (
-      <LandingExtraContainer>
+      <FlexDiv>
         <TranslationDropdown />
         <SignupButton
           type="primary"
@@ -100,7 +94,7 @@ const NavExtra: React.FC<NavExtraProps> = ({
         >
           Log In
         </LoginButton>
-      </LandingExtraContainer>
+      </FlexDiv>
     );
   }
 };

--- a/src/components/navBar/navExtra/index.tsx
+++ b/src/components/navBar/navExtra/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Routes } from '../../../App';
 import styled from 'styled-components';
-import { Avatar, Dropdown, Typography } from 'antd';
+import { Avatar, Dropdown, MenuProps, Typography } from 'antd';
 import { UserOutlined } from '@ant-design/icons';
 import { BLACK, DARK_GREEN, LIGHT_GREEN, WHITE } from '../../../utils/colors';
 import NavMenu from '../navMenu';
 import { Location } from 'history';
 import { GreenLinkButton } from '../../themedComponents';
+import TranslationDropdown from '../translationDropdown';
 
 const FlexDiv = styled.div`
   display: flex;
@@ -60,6 +61,7 @@ const NavExtra: React.FC<NavExtraProps> = ({
   if (userName !== undefined) {
     return (
       <FlexDiv>
+        <TranslationDropdown />
         <Dropdown
           overlay={<NavMenu isAdmin={isAdmin} onLogout={onLogout} />}
           placement="bottomRight"
@@ -75,6 +77,7 @@ const NavExtra: React.FC<NavExtraProps> = ({
   } else {
     return (
       <LandingExtraContainer>
+        <TranslationDropdown />
         <SignupButton
           type="primary"
           htmlType="submit"

--- a/src/components/navBar/navExtra/index.tsx
+++ b/src/components/navBar/navExtra/index.tsx
@@ -15,7 +15,7 @@ const FlexDiv = styled.div`
   margin-right: 20px;
   height: 100%;
   line-height: 9vh;
-  gap: 2vw;
+  gap: 1.8vw;
   align-items: center;
 `;
 
@@ -28,6 +28,10 @@ const LoginButton = styled(GreenLinkButton)`
   background-color: ${WHITE};
   border-color: ${WHITE};
   color: ${BLACK};
+`;
+
+const ExtrasContainer = styled(Typography.Paragraph)`
+  margin-top: 1.6em;
 `;
 
 const Name = styled(Typography.Paragraph)`
@@ -59,12 +63,13 @@ const NavExtra: React.FC<NavExtraProps> = ({
         <Dropdown
           overlay={<NavMenu isAdmin={isAdmin} onLogout={onLogout} />}
           placement="bottomRight"
+          align={{ offset: [0, -25] }}
           arrow
         >
-          <Typography.Paragraph>
+          <ExtrasContainer>
             <Name>{userName}</Name>
             <GreenAvatar size="large" icon={<UserOutlined />} />
-          </Typography.Paragraph>
+          </ExtrasContainer>
         </Dropdown>
       </FlexDiv>
     );

--- a/src/components/navBar/translationDropdown.tsx
+++ b/src/components/navBar/translationDropdown.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Dropdown, MenuProps } from 'antd';
 import i18n from 'i18next';
+import { GlobalOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
 
 const items: MenuProps['items'] = [
   {
@@ -17,10 +19,17 @@ const triggerChangeLang: MenuProps['onClick'] = ({ key }) => {
   i18n.changeLanguage(key);
 };
 
+const TranslationGlobal = styled(GlobalOutlined)`
+  font-size: 25px;
+`;
+
 const TranslationDropdown: React.FC = () => {
   return (
-    <Dropdown menu={{ items, onClick: triggerChangeLang }}>
-      <p>Languages</p>
+    <Dropdown
+      menu={{ items, onClick: triggerChangeLang }}
+      placement="bottomRight"
+    >
+      <TranslationGlobal />
     </Dropdown>
   );
 };

--- a/src/components/navBar/translationDropdown.tsx
+++ b/src/components/navBar/translationDropdown.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Dropdown, MenuProps } from 'antd';
+import i18n from 'i18next';
+
+const items: MenuProps['items'] = [
+  {
+    key: 'en',
+    label: 'English',
+  },
+  {
+    key: 'es',
+    label: 'Español',
+  },
+];
+
+const triggerChangeLang: MenuProps['onClick'] = ({ key }) => {
+  i18n.changeLanguage(key);
+};
+
+const TranslationDropdown: React.FC = () => {
+  return (
+    <Dropdown menu={{ items, onClick: triggerChangeLang }}>
+      <p>Languages</p>
+    </Dropdown>
+  );
+};
+
+export default TranslationDropdown;


### PR DESCRIPTION
## Checklist

- [x] 1. Run `yarn run check`
- [x] 2. Run `yarn run test`

## Why

Resolves #234

Provides a dropdown button for users to switch languages (if available)

## This PR

removed FlexBar component from mobileNavBar, replaced with Flex. There is still some weird alignment issue with the button, so that needs to be fixed

## Screenshots
<img width="281" alt="Screenshot 2024-01-28 at 3 56 13 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/52577512/22a08714-4368-4398-a85f-e72032d43e31">

<img width="1204" alt="Screenshot 2024-01-28 at 3 55 19 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/52577512/3e18035e-3d59-438b-866d-2987ff52a36b">


## Verification Steps

Ran the frontend, changed languages successfully
