### PR TITLE
Emailer: preview HTML content before sending

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -33,4 +33,9 @@ module.exports = {
       ],
     ],
   },
+  jest: {
+    configure: {
+      setupFiles: ['<rootDir>/setup.js'],
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "axios": "^0.21.2",
     "craco-antd": "^2.0.0",
     "i18next": "^23.5.1",
+    "isomorphic-dompurify": "1.4.0",
     "lodash": "^4.17.20",
     "moment": "^2.29.4",
     "react": "^16.13.1",

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,3 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/src/components/forms/sendEmailForm/index.tsx
+++ b/src/components/forms/sendEmailForm/index.tsx
@@ -47,7 +47,7 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
   const [bodyContent, setBodyContent] = useState<string>('');
   const [sanitizedBodyContent, setSanitizedBodyContent] = useState<string>('');
 
-  const switchView = (isShowPreview: boolean) => {
+  const togglePreview = (isShowPreview: boolean) => {
     setShowPreview(isShowPreview);
     isShowPreview && setSanitizedBodyContent(DOMPurify.sanitize(bodyContent));
   };
@@ -89,7 +89,7 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
         <Input placeholder={t('subject_placeholder')} />
       </Form.Item>
       <PreviewSwitch
-        onChange={switchView}
+        onChange={togglePreview}
         checkedChildren={t('preview.preview')}
         unCheckedChildren={t('preview.raw')}
       />

--- a/src/components/forms/sendEmailForm/index.tsx
+++ b/src/components/forms/sendEmailForm/index.tsx
@@ -49,7 +49,7 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
 
   const togglePreview = (isShowPreview: boolean) => {
     setShowPreview(isShowPreview);
-    isShowPreview && setSanitizedBodyContent(DOMPurify.sanitize(bodyContent));
+    if (isShowPreview) setSanitizedBodyContent(DOMPurify.sanitize(bodyContent));
   };
 
   const onFinishSendEmail = (values: SendEmailFormValues) => {
@@ -78,8 +78,8 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
       form={sendEmailForm}
       onFinish={onFinishSendEmail}
       onValuesChange={(changedValues, _) => {
-        changedValues['emailBody'] &&
-          setBodyContent(changedValues['emailBody']);
+        if (changedValues.emailBody !== undefined)
+          setBodyContent(changedValues.emailBody);
       }}
     >
       <Form.Item

--- a/src/components/forms/sendEmailForm/index.tsx
+++ b/src/components/forms/sendEmailForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Form, Input, Switch, message } from 'antd';
 import { SubmitButton } from '../../../components/themedComponents';
@@ -8,23 +8,27 @@ import {
   SendEmailRequest,
 } from '../../../components/forms/ducks/types';
 import { requiredRule } from '../../../utils/formRules';
+import { site } from '../../../constants';
+import { useTranslation } from 'react-i18next';
+import { n } from '../../../utils/stringFormat';
 import DOMPurify from 'isomorphic-dompurify';
 
 const PreviewSwitch = styled(Switch)`
   display: flex;
   align-items: center;
-  // min-width: 80px;
   margin-bottom: 10px;
   padding: 10px 5px;
 `;
 
 const EmailPreview = styled.div`
-  min-height: 200px;
+  min-height: 250px;
   margin-bottom: 24px;
-  max-height: 400px;
+  max-height: 800px;
   border: 1px solid #d9d9d9;
   border-radius: 4px;
   padding: 3px 11px;
+  resize: vertical;
+  overflow-y: scroll; // required for resizing
 `;
 
 interface SendEmailFormProps {
@@ -32,16 +36,28 @@ interface SendEmailFormProps {
 }
 
 const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
+  const { t } = useTranslation(n(site, ['forms']), {
+    keyPrefix: 'volunteer_emailer',
+    nsMode: 'fallback',
+  });
+
   const [sendEmailForm] = Form.useForm();
 
   const [showPreview, setShowPreview] = useState<boolean>(false);
   const [bodyContent, setBodyContent] = useState<string>('');
-  const sanitizedBodyContent = useMemo(
-    () => DOMPurify.sanitize(bodyContent),
-    [bodyContent],
-  );
+  const [sanitizedBodyContent, setSanitizedBodyContent] = useState<string>('');
+
+  const switchView = (isShowPreview: boolean) => {
+    setShowPreview(isShowPreview);
+    isShowPreview && setSanitizedBodyContent(DOMPurify.sanitize(bodyContent));
+  };
 
   const onFinishSendEmail = (values: SendEmailFormValues) => {
+    if (emails.length === 0) {
+      message.error(t('users_required'));
+      return;
+    }
+
     const sendEmailRequest: SendEmailRequest = {
       ...values,
       emails,
@@ -49,10 +65,10 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
 
     ProtectedApiClient.sendEmail(sendEmailRequest)
       .then(() => {
-        message.success('Email sent!');
+        message.success(t('success'));
       })
       .catch((err) =>
-        message.error(`Email could not be sent: ${err.response.data}`),
+        message.error(t('response_error', { error: err.response.data })),
       );
   };
 
@@ -68,29 +84,29 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
     >
       <Form.Item
         name="emailSubject"
-        rules={requiredRule('The email subject is required')}
+        rules={requiredRule(t('subject_required'))}
       >
-        <Input placeholder="Email Subject" />
+        <Input placeholder={t('subject_placeholder')} />
       </Form.Item>
       <PreviewSwitch
-        onChange={(checked) => setShowPreview(checked)}
-        checkedChildren="Preview"
-        unCheckedChildren="Raw"
+        onChange={switchView}
+        checkedChildren={t('preview.preview')}
+        unCheckedChildren={t('preview.raw')}
       />
-      {showPreview ? (
+      <Form.Item
+        name="emailBody"
+        rules={requiredRule(t('body_required'))}
+        hidden={showPreview}
+      >
+        <Input.TextArea rows={8} placeholder={t('body_placeholder')} />
+      </Form.Item>
+      {showPreview && (
         <EmailPreview
           dangerouslySetInnerHTML={{ __html: sanitizedBodyContent }}
         />
-      ) : (
-        <Form.Item
-          name="emailBody"
-          rules={requiredRule('The email body is required')}
-        >
-          <Input.TextArea rows={6} placeholder="Email Body" />
-        </Form.Item>
       )}
       <SubmitButton type="primary" htmlType="submit">
-        Send Email
+        {t('send')}
       </SubmitButton>
     </Form>
   );

--- a/src/components/forms/sendEmailForm/index.tsx
+++ b/src/components/forms/sendEmailForm/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Form, Input, message } from 'antd';
+import React, { useState, useMemo } from 'react';
+import styled from 'styled-components';
+import { Form, Input, Switch, message } from 'antd';
 import { SubmitButton } from '../../../components/themedComponents';
 import ProtectedApiClient from '../../../api/protectedApiClient';
 import {
@@ -7,6 +8,24 @@ import {
   SendEmailRequest,
 } from '../../../components/forms/ducks/types';
 import { requiredRule } from '../../../utils/formRules';
+import DOMPurify from 'isomorphic-dompurify';
+
+const PreviewSwitch = styled(Switch)`
+  display: flex;
+  align-items: center;
+  // min-width: 80px;
+  margin-bottom: 10px;
+  padding: 10px 5px;
+`;
+
+const EmailPreview = styled.div`
+  min-height: 200px;
+  margin-bottom: 24px;
+  max-height: 400px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  padding: 3px 11px;
+`;
 
 interface SendEmailFormProps {
   readonly emails: string[];
@@ -14,6 +33,13 @@ interface SendEmailFormProps {
 
 const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
   const [sendEmailForm] = Form.useForm();
+
+  const [showPreview, setShowPreview] = useState<boolean>(false);
+  const [bodyContent, setBodyContent] = useState<string>('');
+  const sanitizedBodyContent = useMemo(
+    () => DOMPurify.sanitize(bodyContent),
+    [bodyContent],
+  );
 
   const onFinishSendEmail = (values: SendEmailFormValues) => {
     const sendEmailRequest: SendEmailRequest = {
@@ -31,21 +57,38 @@ const SendEmailForm: React.FC<SendEmailFormProps> = ({ emails }) => {
   };
 
   return (
-    <Form name="sendEmail" form={sendEmailForm} onFinish={onFinishSendEmail}>
+    <Form
+      name="sendEmail"
+      form={sendEmailForm}
+      onFinish={onFinishSendEmail}
+      onValuesChange={(changedValues, _) => {
+        changedValues['emailBody'] &&
+          setBodyContent(changedValues['emailBody']);
+      }}
+    >
       <Form.Item
         name="emailSubject"
         rules={requiredRule('The email subject is required')}
       >
         <Input placeholder="Email Subject" />
       </Form.Item>
-
-      <Form.Item
-        name="emailBody"
-        rules={requiredRule('The email body is required')}
-      >
-        <Input.TextArea rows={6} placeholder="Email Body" />
-      </Form.Item>
-
+      <PreviewSwitch
+        onChange={(checked) => setShowPreview(checked)}
+        checkedChildren="Preview"
+        unCheckedChildren="Raw"
+      />
+      {showPreview ? (
+        <EmailPreview
+          dangerouslySetInnerHTML={{ __html: sanitizedBodyContent }}
+        />
+      ) : (
+        <Form.Item
+          name="emailBody"
+          rules={requiredRule('The email body is required')}
+        >
+          <Input.TextArea rows={6} placeholder="Email Body" />
+        </Form.Item>
+      )}
       <SubmitButton type="primary" htmlType="submit">
         Send Email
       </SubmitButton>

--- a/src/i18n/en/forms.json
+++ b/src/i18n/en/forms.json
@@ -121,5 +121,19 @@
     },
     "date_label": "Activity Date",
     "activity_label": "Stewardship Activities"
+  },
+  "volunteer_emailer": {
+    "success": "Email sent!",
+    "users_required": "Please select users to email",
+    "response_error": "Email could not be sent: {{error}}",
+    "subject_required": "The email subject is required",
+    "subject_placeholder": "Email Subject",
+    "preview": {
+      "preview": "Preview",
+      "raw": "Raw"
+    },
+    "body_required": "The email body is required",
+    "body_placeholder": "Email Body",
+    "send": "Send Email"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -2238,6 +2243,13 @@
   integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
   dependencies:
     "@types/node" "*"
+
+"@types/dompurify@^3.0.1":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.5.tgz#02069a2fcb89a163bacf1a788f73cb415dd75cb7"
+  integrity sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==
+  dependencies:
+    "@types/trusted-types" "*"
 
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
@@ -2560,6 +2572,11 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
+"@types/trusted-types@*":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/trusted-types@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
@@ -2832,7 +2849,7 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.3, abab@^2.0.5:
+abab@^2.0.3, abab@^2.0.5, abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
@@ -4262,6 +4279,13 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+cssstyle@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-3.0.0.tgz#17ca9c87d26eac764bb8cfd00583cff21ce0277a"
+  integrity sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==
+  dependencies:
+    rrweb-cssom "^0.6.0"
+
 csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
@@ -4287,6 +4311,15 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+data-urls@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-4.0.0.tgz#333a454eca6f9a5b7b0f1013ff89074c3f522dd4"
+  integrity sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^12.0.0"
 
 date-fns@2.x:
   version "2.30.0"
@@ -4321,7 +4354,7 @@ debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-decimal.js@^10.2.1:
+decimal.js@^10.2.1, decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
@@ -4523,12 +4556,24 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
+
 domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.8.tgz#e0021ab1b09184bc8af7e35c7dd9063f43a8a437"
+  integrity sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==
 
 domutils@^1.7.0:
   version "1.7.0"
@@ -4637,6 +4682,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 errno@^0.1.1:
   version "0.1.8"
@@ -5370,6 +5420,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -5732,6 +5791,13 @@ html-encoding-sniffer@^2.0.1:
   dependencies:
     whatwg-encoding "^1.0.5"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-entities@^2.1.0, html-entities@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.4.0.tgz#edd0cee70402584c8c76cc2c0556db09d1f45061"
@@ -5823,6 +5889,15 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-proxy-middleware@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
@@ -5852,7 +5927,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -5879,7 +5954,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -6270,6 +6345,15 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-dompurify@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-dompurify/-/isomorphic-dompurify-1.4.0.tgz#8930390eafa4f0390de38cf6824390bdaebdce4e"
+  integrity sha512-00ZbtXXRnmXfA6VoJwvYtOPgDbPw+Sgmiu12VpesAIoD+V6rjTyf2KEbig/yRfXztBBfcrk3S/X8xu1XNy5kzw==
+  dependencies:
+    "@types/dompurify" "^3.0.1"
+    dompurify "^3.0.2"
+    jsdom "^22.0.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6960,6 +7044,35 @@ jsdom@^16.6.0:
     ws "^7.4.6"
     xml-name-validator "^3.0.0"
 
+jsdom@^22.0.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-22.1.0.tgz#0fca6d1a37fbeb7f4aac93d1090d782c56b611c8"
+  integrity sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==
+  dependencies:
+    abab "^2.0.6"
+    cssstyle "^3.0.0"
+    data-urls "^4.0.0"
+    decimal.js "^10.4.3"
+    domexception "^4.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.4"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.6.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^4.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^12.0.1"
+    ws "^8.13.0"
+    xml-name-validator "^4.0.0"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -7588,7 +7701,7 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nwsapi@^2.2.0:
+nwsapi@^2.2.0, nwsapi@^2.2.4:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
   integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
@@ -7818,6 +7931,13 @@ parse5@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parse5@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -8614,6 +8734,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+punycode@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 q@^1.1.2:
   version "1.5.1"
@@ -9589,6 +9714,11 @@ rollup@^2.43.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+  integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -9652,6 +9782,13 @@ saxes@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+  dependencies:
+    xmlchars "^2.2.0"
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
   dependencies:
     xmlchars "^2.2.0"
 
@@ -10458,7 +10595,7 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
-tough-cookie@^4.0.0:
+tough-cookie@^4.0.0, tough-cookie@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
   integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
@@ -10489,6 +10626,13 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tr46@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-4.1.1.tgz#281a758dcc82aeb4fe38c7dfe4d11a395aac8469"
+  integrity sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==
+  dependencies:
+    punycode "^2.3.0"
 
 tryer@^1.0.1:
   version "1.0.1"
@@ -10865,6 +11009,13 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+w3c-xmlserializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073"
+  integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 walker@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -10901,6 +11052,11 @@ webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
@@ -11037,6 +11193,13 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.6.2:
   version "3.6.18"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.18.tgz#2f640cdee315abced7daeaed2309abd1e44e62d4"
@@ -11046,6 +11209,19 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^12.0.0, whatwg-url@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-12.0.1.tgz#fd7bcc71192e7c3a2a97b9a8d6b094853ed8773c"
+  integrity sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==
+  dependencies:
+    tr46 "^4.1.1"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"
@@ -11341,6 +11517,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Checklist

- [x] 1. Run `yarn run check`
- [x] 2. Run `yarn run test`

## Why

Resolves #275 

<!-- What benefit does this bring to the end user? Or, what benefit does this bring to developers working in the codebase? -->

On the emailer page, add a toggle to preview email HTML before sending

## This PR

<!-- Describe the changes required and any implementation choices you made to give context to reviewers. -->

- Add DOMpurify as a dependency to sanitize HTML
- Add a switch to toggle between the raw HTML editor and email previewing 

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

Raw view:

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/20c06a32-95c9-4ee6-9f0f-01c3fcf196b9)

Preview view:

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/7f1d40dd-c63b-4dd0-ba63-1c0616bce567)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->

- Verified the switch toggles between raw and preview views
- Verified HTML content is sanitized in the preview view
