### PR TITLE
Sk.add map to tree page

### DIFF
--- a/src/components/mapComponents/mapDisplays/selectorMapDisplay/index.tsx
+++ b/src/components/mapComponents/mapDisplays/selectorMapDisplay/index.tsx
@@ -21,6 +21,7 @@ interface SelectorMapDisplayProps {
   readonly onMove: (pos: google.maps.LatLng) => void;
   readonly site?: SiteProps;
   readonly setMarker: (marker: google.maps.Marker) => void;
+  readonly mapHeight?: string;
 }
 
 const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
@@ -29,6 +30,7 @@ const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
   onMove,
   site,
   setMarker,
+  mapHeight = '100%',
 }) => (
   <>
     {asyncRequestIsComplete(neighborhoods) && asyncRequestIsComplete(sites) && (
@@ -38,6 +40,7 @@ const SelectorMapDisplay: React.FC<SelectorMapDisplayProps> = ({
         onMove={onMove}
         site={site}
         setMarker={setMarker}
+        mapHeight={mapHeight}
       />
     )}
     {(asyncRequestIsFailed(neighborhoods) || asyncRequestIsFailed(sites)) && (

--- a/src/components/mapComponents/maps/mapWithPopup/index.tsx
+++ b/src/components/mapComponents/maps/mapWithPopup/index.tsx
@@ -29,8 +29,8 @@ const StyledSearch = styled(Input.Search)`
   }
 `;
 
-const MapDiv = styled.div`
-  height: 100%;
+const MapDiv = styled.div<{ height: string }>`
+  height: ${(props) => props.height || 0};
 `;
 
 interface MapWithPopupProps {
@@ -40,6 +40,7 @@ interface MapWithPopupProps {
   readonly lng: number;
   readonly initMap: (mapData: InitMapData) => ReturnMapData;
   readonly defaultActiveTree: BasicTreeInfo;
+  readonly mapHeight?: string;
 }
 
 let map: google.maps.Map;
@@ -51,6 +52,7 @@ const MapWithPopup: React.FC<PropsWithChildren<MapWithPopupProps>> = ({
   lat,
   lng,
   initMap,
+  mapHeight = '100%',
   defaultActiveTree,
   children,
 }) => {
@@ -222,7 +224,7 @@ const MapWithPopup: React.FC<PropsWithChildren<MapWithPopupProps>> = ({
           onChange={(event) => setSearchInput(event.target.value)}
         />
       </div>
-      <MapDiv id="map" ref={mapRef} />
+      <MapDiv id="map" ref={mapRef} height={mapHeight} />
       <TreePopup treeInfo={activeTreeInfo} popRef={treePopupRef} />
       {children}
     </>

--- a/src/components/mapComponents/maps/selectorMap/index.tsx
+++ b/src/components/mapComponents/maps/selectorMap/index.tsx
@@ -20,6 +20,7 @@ interface SelectorMapProps {
   readonly onMove: (pos: google.maps.LatLng) => void;
   readonly site?: SiteProps;
   readonly setMarker: (marker: google.maps.Marker) => void;
+  readonly mapHeight?: string;
 }
 
 const SelectorMap: React.FC<SelectorMapProps> = ({
@@ -28,6 +29,7 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
   onMove,
   site,
   setMarker,
+  mapHeight = '100%',
 }) => {
   const defaultZoom = STREET_ZOOM;
 
@@ -98,6 +100,7 @@ const SelectorMap: React.FC<SelectorMapProps> = ({
       lat={defaultCenter.lat}
       lng={defaultCenter.lng}
       initMap={setSearchMarkerAndInitSiteMap}
+      mapHeight={mapHeight}
       defaultActiveTree={basicSite}
     />
   );

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -134,9 +134,6 @@ const TreePage: React.FC<TreeProps> = ({
     nsMode: 'fallback',
   });
 
-  const [editSiteForm] = Form.useForm();
-  const [mapSearchMarker, setMapSearchMarker] = useState<google.maps.Marker>();
-
   const location = useLocation<RedirectStateProps>();
 
   const dispatch = useDispatch();
@@ -340,14 +337,11 @@ const TreePage: React.FC<TreeProps> = ({
                             <SelectorMapDisplay
                               neighborhoods={neighborhoods}
                               sites={sites}
-                              onMove={(pos: google.maps.LatLng) => {
-                                editSiteForm.setFieldsValue({
-                                  lat: round(pos.lat(), LAT_LNG_PRECISION),
-                                  lng: round(pos.lng(), LAT_LNG_PRECISION),
-                                });
-                              }}
+                              // eslint-disable-next-line @typescript-eslint/no-empty-function
+                              onMove={() => {}}
                               site={siteData.result}
-                              setMarker={setMapSearchMarker}
+                              // eslint-disable-next-line @typescript-eslint/no-empty-function
+                              setMarker={() => {}}
                               mapHeight={'50%'}
                             />
 

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -347,6 +347,7 @@ const TreePage: React.FC<TreeProps> = ({
                                 });
                               }}
                               setMarker={setMapSearchMarker}
+                              mapHeight={'50%'}
                             />
 
                             <TreeBenefits />

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import PageLayout from '../../components/pageLayout';
@@ -52,6 +52,10 @@ import { Trans, useTranslation } from 'react-i18next';
 import { site } from '../../constants';
 import { n } from '../../utils/stringFormat';
 import TreeBenefits from '../../components/treePage/treeBenefits';
+import SelectorMapDisplay from '../../components/mapComponents/mapDisplays/selectorMapDisplay';
+import { round } from 'lodash';
+import { LAT_LNG_PRECISION } from '../../components/forms/constants';
+import { MapGeoDataReducerState } from '../../components/mapComponents/ducks/types';
 
 const TreePageContainer = styled.div`
   width: 90vw;
@@ -105,6 +109,8 @@ const TreePlantingRequestContainer = styled.div`
 `;
 
 interface TreeProps {
+  readonly neighborhoods: MapGeoDataReducerState['neighborhoodGeoData'];
+  readonly sites: MapGeoDataReducerState['siteGeoData'];
   readonly tokens: UserAuthenticationReducerState['tokens'];
   readonly siteData: SiteReducerState['siteData'];
   readonly stewardship: TreeCare[];
@@ -117,6 +123,8 @@ export interface TreeParams {
 }
 
 const TreePage: React.FC<TreeProps> = ({
+  sites,
+  neighborhoods,
   siteData,
   stewardship,
   monthYearOptions,
@@ -125,6 +133,9 @@ const TreePage: React.FC<TreeProps> = ({
   const { t } = useTranslation(n(site, ['treePage', 'forms']), {
     nsMode: 'fallback',
   });
+
+  const [editSiteForm] = Form.useForm();
+  const [mapSearchMarker, setMapSearchMarker] = useState<google.maps.Marker>();
 
   const location = useLocation<RedirectStateProps>();
 
@@ -326,6 +337,18 @@ const TreePage: React.FC<TreeProps> = ({
 
                             <SiteImageCarousel />
 
+                            <SelectorMapDisplay
+                              neighborhoods={neighborhoods}
+                              sites={sites}
+                              onMove={(pos: google.maps.LatLng) => {
+                                editSiteForm.setFieldsValue({
+                                  lat: round(pos.lat(), LAT_LNG_PRECISION),
+                                  lng: round(pos.lng(), LAT_LNG_PRECISION),
+                                });
+                              }}
+                              setMarker={setMapSearchMarker}
+                            />
+
                             <TreeBenefits />
                           </HalfWidthContainer>
                         </Flex>
@@ -453,6 +476,8 @@ const TreePlantingRequest: React.FC = () => {
 
 const mapStateToProps = (state: C4CState): TreeProps => {
   return {
+    neighborhoods: state.mapGeoDataState.neighborhoodGeoData,
+    sites: state.mapGeoDataState.siteGeoData,
     tokens: state.authenticationState.tokens,
     siteData: state.siteState.siteData,
     stewardship: mapStewardshipToTreeCare(

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -346,6 +346,7 @@ const TreePage: React.FC<TreeProps> = ({
                                   lng: round(pos.lng(), LAT_LNG_PRECISION),
                                 });
                               }}
+                              site={siteData.result}
                               setMarker={setMapSearchMarker}
                               mapHeight={'50%'}
                             />


### PR DESCRIPTION
## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #325

This change adds a map to the tree info page, allowing users to see where the tree exists relative to other trees and the entire map of Boston

## This PR

DUPLICATED IN https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/337

Changes include
- Adding a map height parameter to make the height of the map component specifiable depending on where it is called from
- Adding sites and neighborhoods fields to tree props so that the map component can display the entire map of all other sites
- Define a state for the map marker and position
- Add the actual map component to a tree page

## Screenshots

<img width="620" alt="Screenshot 2024-02-28 at 4 23 03 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/326eecc5-f9bb-4f3b-9c90-6c71b34e2cba">
<img width="622" alt="Screenshot 2024-02-28 at 4 22 55 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/c4ec0256-c4d0-455c-837a-a1d364bda4b4">

## Verification Steps

To verify that this works
- Select a site from the home page
- Select 'More Info', open in a new tab
- Note that a map exists on the more info page
- Ensure that the map position on the tree page matches the tree position on the home page