### PR TITLE
Add dispatch to fix tree page map buffering

### DIFF
--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -53,9 +53,8 @@ import { site } from '../../constants';
 import { n } from '../../utils/stringFormat';
 import TreeBenefits from '../../components/treePage/treeBenefits';
 import SelectorMapDisplay from '../../components/mapComponents/mapDisplays/selectorMapDisplay';
-import { round } from 'lodash';
-import { LAT_LNG_PRECISION } from '../../components/forms/constants';
 import { MapGeoDataReducerState } from '../../components/mapComponents/ducks/types';
+import { getMapGeoData } from '../../components/mapComponents/ducks/thunks';
 
 const TreePageContainer = styled.div`
   width: 90vw;
@@ -148,6 +147,7 @@ const TreePage: React.FC<TreeProps> = ({
     if (asyncRequestIsComplete(tokens)) {
       dispatch(getAdoptedSites());
     }
+    dispatch(getMapGeoData());
   }, [dispatch, id, tokens]);
 
   const onFinishRecordStewardship = (values: RecordStewardshipRequest) => {


### PR DESCRIPTION
## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #325

This change adds a map to the tree info page, allowing users to see where the tree exists relative to other trees and the entire map of Boston

## This PR

ADDITION TO
https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/337
https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/327

Changes include
- Adding a map height parameter to make the height of the map component specifiable depending on where it is called from
- Adding sites and neighborhoods fields to tree props so that the map component can display the entire map of all other sites
- Define a state for the map marker and position
- Add the actual map component to a tree page

## Screenshots

<img width="620" alt="Screenshot 2024-02-28 at 4 23 03 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/326eecc5-f9bb-4f3b-9c90-6c71b34e2cba">
<img width="622" alt="Screenshot 2024-02-28 at 4 22 55 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/c4ec0256-c4d0-455c-837a-a1d364bda4b4">

## Verification Steps

To verify that this works
- Select a site from the home page
- Select 'More Info', open in a new tab
- Note that a map exists on the more info page
- Ensure that the map position on the tree page matches the tree position on the home page