### PR TITLE
Sk.add map to tree page fix b UI ld

### DIFF
--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -134,9 +134,6 @@ const TreePage: React.FC<TreeProps> = ({
     nsMode: 'fallback',
   });
 
-  const [editSiteForm] = Form.useForm();
-  const [mapSearchMarker, setMapSearchMarker] = useState<google.maps.Marker>();
-
   const location = useLocation<RedirectStateProps>();
 
   const dispatch = useDispatch();
@@ -340,14 +337,11 @@ const TreePage: React.FC<TreeProps> = ({
                             <SelectorMapDisplay
                               neighborhoods={neighborhoods}
                               sites={sites}
-                              onMove={(pos: google.maps.LatLng) => {
-                                editSiteForm.setFieldsValue({
-                                  lat: round(pos.lat(), LAT_LNG_PRECISION),
-                                  lng: round(pos.lng(), LAT_LNG_PRECISION),
-                                });
-                              }}
+                              // eslint-disable-next-line @typescript-eslint/no-empty-function
+                              onMove={() => {}}
                               site={siteData.result}
-                              setMarker={setMapSearchMarker}
+                              // eslint-disable-next-line @typescript-eslint/no-empty-function
+                              setMarker={() => {}}
                               mapHeight={'50%'}
                             />
 


### PR DESCRIPTION
## Checklist

- [X] 1. Run `yarn run check`
- [X] 2. Run `yarn run test`

## Why

Resolves #325

This change adds a map to the tree info page, allowing users to see where the tree exists relative to other trees and the entire map of Boston

## This PR

DUPLICATE OF https://github.com/Code-4-Community/speak-for-the-trees-frontend/pull/327

Changes include
- Adding a map height parameter to make the height of the map component specifiable depending on where it is called from
- Adding sites and neighborhoods fields to tree props so that the map component can display the entire map of all other sites
- Define a state for the map marker and position
- Add the actual map component to a tree page

## Screenshots

<img width="620" alt="Screenshot 2024-02-28 at 4 23 03 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/326eecc5-f9bb-4f3b-9c90-6c71b34e2cba">
<img width="622" alt="Screenshot 2024-02-28 at 4 22 55 PM" src="https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/30560773/c4ec0256-c4d0-455c-837a-a1d364bda4b4">

## Verification Steps

To verify that this works
- Select a site from the home page
- Select 'More Info', open in a new tab
- Note that a map exists on the more info page
- Ensure that the map position on the tree page matches the tree position on the home page