### PR TITLE
Add User Site Reporting to Tree Page

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -23,6 +23,7 @@ import {
 } from '../components/forms/ducks/types';
 import {
   ActivityRequest,
+  ReportSiteRequest,
   AdoptedSites,
 } from '../containers/treePage/ducks/types';
 import {
@@ -142,6 +143,10 @@ export interface ProtectedApiClient {
   readonly loadEmailTemplateContent: (
     templateName: string,
   ) => Promise<LoadTemplateResponse>;
+  readonly reportSiteForIssues: (
+    siteId: number,
+    request: ReportSiteRequest,
+  ) => Promise<void>;
 }
 
 export enum ProtectedApiClientRoutes {
@@ -214,6 +219,7 @@ export const ParameterizedApiRoutes = {
     `${baseSiteRoute}site_image/${siteEntryId}`,
   DELETE_IMAGE: (imageId: number): string =>
     `${baseSiteRoute}site_image/${imageId}`,
+  REPORT_SITE: (siteId: number): string => `${baseSiteRoute}${siteId}/report`,
 };
 
 export const ParameterizedAdminApiRoutes = {
@@ -614,6 +620,16 @@ const loadEmailTemplateContent = (
   ).then((res) => res.data);
 };
 
+const reportSiteForIssues = (
+  siteId: number,
+  request: ReportSiteRequest,
+): Promise<void> => {
+  return AppAxiosInstance.post(
+    ParameterizedApiRoutes.REPORT_SITE(siteId),
+    request,
+  ).then((res) => res.data);
+};
+
 const Client: ProtectedApiClient = Object.freeze({
   makeReservation,
   completeReservation,
@@ -666,6 +682,7 @@ const Client: ProtectedApiClient = Object.freeze({
   uploadImage,
   getEmailTemplateNames,
   loadEmailTemplateContent,
+  reportSiteForIssues,
 });
 
 export default Client;

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -2287,7 +2287,7 @@ describe('Admin Protected Client Routes', () => {
       };
 
       nock(BASE_URL)
-        .get(ParameterizedApiRoutes.REPORT_SITE(100))
+        .post(ParameterizedApiRoutes.REPORT_SITE(100))
         .reply(200, response);
 
       const result = await ProtectedApiClient.reportSiteForIssues(100, params);
@@ -2304,7 +2304,7 @@ describe('Admin Protected Client Routes', () => {
       };
 
       nock(BASE_URL)
-        .get(ParameterizedApiRoutes.REPORT_SITE(100))
+        .post(ParameterizedApiRoutes.REPORT_SITE(100))
         .reply(400, response);
 
       const result = await ProtectedApiClient.reportSiteForIssues(

--- a/src/api/test/protectedApiClient.test.ts
+++ b/src/api/test/protectedApiClient.test.ts
@@ -2276,4 +2276,43 @@ describe('Admin Protected Client Routes', () => {
       ).catch((err) => err.response.data);
     });
   });
+
+  describe('reportSiteForIssues', () => {
+    it('makes the right request', async () => {
+      const response = '';
+
+      const params = {
+        reason: 'Tree Bad',
+        description: 'just awful',
+      };
+
+      nock(BASE_URL)
+        .get(ParameterizedApiRoutes.REPORT_SITE(100))
+        .reply(200, response);
+
+      const result = await ProtectedApiClient.reportSiteForIssues(100, params);
+
+      expect(result).toEqual(response);
+    });
+
+    it('makes a bad request', async () => {
+      const response = 'Malformed request body!';
+
+      const params = {
+        reason: '',
+        description: 'missing a reason',
+      };
+
+      nock(BASE_URL)
+        .get(ParameterizedApiRoutes.REPORT_SITE(100))
+        .reply(400, response);
+
+      const result = await ProtectedApiClient.reportSiteForIssues(
+        100,
+        params,
+      ).catch((err) => err.response.data);
+
+      expect(result).toEqual(response);
+    });
+  });
 });

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -40,7 +40,7 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
       name="reportSite"
       onFinish={onFinish}
       form={form}
-      onValuesChange={(_, allValues) => setSubmitDisabled(!allValues['reason'])}
+      onValuesChange={(_, allValues) => setSubmitDisabled(!allValues.reason)}
     >
       <ItemLabel>{t('report_site.reason_label')}</ItemLabel>
       <Form.Item
@@ -52,7 +52,7 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
       <ItemLabel style={{ marginTop: '15px' }}>
         {t('report_site.description_label')}
       </ItemLabel>
-      <Form.Item name="description">
+      <Form.Item name="description" initialValue="">
         <Input.TextArea
           rows={3}
           placeholder={t('report_site.description_placeholder')}

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -36,10 +36,15 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
   return (
     <Form name="reportSite" onFinish={onFinish} form={form}>
       <ItemLabel>{t('report_site.reason_label')}</ItemLabel>
-      <Form.Item name="reason" rules={requiredRule('A reason is required!')}>
+      <Form.Item
+        name="reason"
+        rules={requiredRule(t('report_site.reason_rule'))}
+      >
         <Radio.Group options={reasonOptions} />
       </Form.Item>
-      <ItemLabel>{t('report_site.description_label')}</ItemLabel>
+      <ItemLabel style={{ marginTop: '15px' }}>
+        {t('report_site.description_label')}
+      </ItemLabel>
       <Form.Item name="description">
         <Input.TextArea
           rows={3}

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Radio, Input, Typography, Form, FormInstance } from 'antd';
+import { Input, Typography, Form, FormInstance, Select } from 'antd';
 import { SubmitButton } from '../../themedComponents';
 import { requiredRule } from '../../../utils/formRules';
 import { ReportSiteRequest } from '../../../containers/treePage/ducks/types';
@@ -47,7 +47,7 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
         name="reason"
         rules={requiredRule(t('report_site.reason_rule'))}
       >
-        <Radio.Group options={reasonOptions} />
+        <Select options={reasonOptions} placeholder="Select a reason" />
       </Form.Item>
       <ItemLabel style={{ marginTop: '15px' }}>
         {t('report_site.description_label')}

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Radio, Input, Typography, Form, FormInstance } from 'antd';
+import { SubmitButton } from '../../themedComponents';
+import { requiredRule } from '../../../utils/formRules';
+import { ReportSiteRequest } from '../../../containers/treePage/ducks/types';
+
+const ItemLabel = styled(Typography.Paragraph)`
+  line-height: 0px;
+`;
+
+interface ReportSiteFormProps {
+  form: FormInstance;
+  onFinish: (reportInfo: ReportSiteRequest) => void;
+}
+
+const reasonOptions = ['Inappropriate Content', 'Incorrect Information'];
+
+const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
+  return (
+    <Form name="reportSite" onFinish={onFinish} form={form}>
+      <ItemLabel>Reason</ItemLabel>
+      <Form.Item name="reason" rules={requiredRule('A reason is required!')}>
+        <Radio.Group options={reasonOptions} />
+      </Form.Item>
+      <ItemLabel>Description (optional)</ItemLabel>
+      <Form.Item name="description">
+        <Input.TextArea
+          rows={3}
+          placeholder="Describe the issue in greater detail"
+          maxLength={500}
+          showCount
+        />
+      </Form.Item>
+      <Form.Item>
+        <SubmitButton htmlType="submit">Submit</SubmitButton>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default ReportSiteForm;

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Radio, Input, Typography, Form, FormInstance } from 'antd';
 import { SubmitButton } from '../../themedComponents';
@@ -33,8 +33,15 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
     },
   ];
 
+  const [submitDisabled, setSubmitDisabled] = useState<boolean>(true);
+
   return (
-    <Form name="reportSite" onFinish={onFinish} form={form}>
+    <Form
+      name="reportSite"
+      onFinish={onFinish}
+      form={form}
+      onValuesChange={(_, allValues) => setSubmitDisabled(!allValues['reason'])}
+    >
       <ItemLabel>{t('report_site.reason_label')}</ItemLabel>
       <Form.Item
         name="reason"
@@ -54,7 +61,9 @@ const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
         />
       </Form.Item>
       <Form.Item style={{ marginBottom: '0px;' }}>
-        <SubmitButton htmlType="submit">{t('submit')}</SubmitButton>
+        <SubmitButton htmlType="submit" disabled={submitDisabled}>
+          {t('submit')}
+        </SubmitButton>
       </Form.Item>
     </Form>
   );

--- a/src/components/forms/reportSiteForm/index.tsx
+++ b/src/components/forms/reportSiteForm/index.tsx
@@ -4,6 +4,9 @@ import { Radio, Input, Typography, Form, FormInstance } from 'antd';
 import { SubmitButton } from '../../themedComponents';
 import { requiredRule } from '../../../utils/formRules';
 import { ReportSiteRequest } from '../../../containers/treePage/ducks/types';
+import { useTranslation } from 'react-i18next';
+import { site } from '../../../constants';
+import { n } from '../../../utils/stringFormat';
 
 const ItemLabel = styled(Typography.Paragraph)`
   line-height: 0px;
@@ -14,26 +17,39 @@ interface ReportSiteFormProps {
   onFinish: (reportInfo: ReportSiteRequest) => void;
 }
 
-const reasonOptions = ['Inappropriate Content', 'Incorrect Information'];
-
 const ReportSiteForm: React.FC<ReportSiteFormProps> = ({ form, onFinish }) => {
+  const { t } = useTranslation(n(site, ['forms']), {
+    nsMode: 'fallback',
+  });
+
+  const reasonOptions = [
+    {
+      value: 'Inappropriate Content',
+      label: t('report_site.options.inappropriate'),
+    },
+    {
+      value: 'Incorrect Information',
+      label: t('report_site.options.incorrect'),
+    },
+  ];
+
   return (
     <Form name="reportSite" onFinish={onFinish} form={form}>
-      <ItemLabel>Reason</ItemLabel>
+      <ItemLabel>{t('report_site.reason_label')}</ItemLabel>
       <Form.Item name="reason" rules={requiredRule('A reason is required!')}>
         <Radio.Group options={reasonOptions} />
       </Form.Item>
-      <ItemLabel>Description (optional)</ItemLabel>
+      <ItemLabel>{t('report_site.description_label')}</ItemLabel>
       <Form.Item name="description">
         <Input.TextArea
           rows={3}
-          placeholder="Describe the issue in greater detail"
+          placeholder={t('report_site.description_placeholder')}
           maxLength={500}
           showCount
         />
       </Form.Item>
-      <Form.Item>
-        <SubmitButton htmlType="submit">Submit</SubmitButton>
+      <Form.Item style={{ marginBottom: '0px;' }}>
+        <SubmitButton htmlType="submit">{t('submit')}</SubmitButton>
       </Form.Item>
     </Form>
   );

--- a/src/components/reportSiteButton/index.tsx
+++ b/src/components/reportSiteButton/index.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { site } from '../../constants';
 import { n } from '../../utils/stringFormat';
+import DOMPurify from 'isomorphic-dompurify';
 
 const StyledReportButton = styled(Button)`
   padding: 0 10px;
@@ -39,7 +40,10 @@ const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({ siteId }) => {
 
   function reportSite(reportInfo: ReportSiteRequest) {
     protectedApiClient
-      .reportSiteForIssues(siteId, reportInfo)
+      .reportSiteForIssues(siteId, {
+        ...reportInfo,
+        description: DOMPurify.sanitize(reportInfo.description),
+      })
       .then(() => {
         message.success(t('messages.report_success'));
         setShowReportModal(false);

--- a/src/components/reportSiteButton/index.tsx
+++ b/src/components/reportSiteButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import protectedApiClient from '../../api/protectedApiClient';
 import { StyledClose } from '../themedComponents';
 import { ReportSiteRequest } from '../../containers/treePage/ducks/types';
@@ -37,22 +37,19 @@ const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({ siteId }) => {
   const [showReportModal, setShowReportModal] = useState<boolean>(false);
   const [reportSiteForm] = Form.useForm();
 
-  const reportSite = useCallback(
-    (reportInfo: ReportSiteRequest) => {
-      protectedApiClient
-        .reportSiteForIssues(siteId, reportInfo)
-        .then(() => {
-          message.success(t('messages.report_success'));
-          setShowReportModal(false);
-        })
-        .catch((err) => {
-          message.error(
-            t('messages.report_failure', { error: err.response.data }),
-          );
-        });
-    },
-    [setShowReportModal],
-  );
+  function reportSite(reportInfo: ReportSiteRequest) {
+    protectedApiClient
+      .reportSiteForIssues(siteId, reportInfo)
+      .then(() => {
+        message.success(t('messages.report_success'));
+        setShowReportModal(false);
+      })
+      .catch((err) => {
+        message.error(
+          t('messages.report_failure', { error: err.response.data }),
+        );
+      });
+  }
 
   return (
     <>

--- a/src/components/reportSiteButton/index.tsx
+++ b/src/components/reportSiteButton/index.tsx
@@ -21,19 +21,15 @@ const StyledReportButton = styled(Button)`
 
 const ReportIcon = styled(FlagOutlined)`
   max-height: 25px;
-  font-size: 20px;
+  font-size: 22px;
   vertical-align: middle;
 `;
 
 interface ReportSiteButtonProps {
   siteId: number;
-  mobile?: boolean;
 }
 
-const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({
-  siteId,
-  mobile,
-}) => {
+const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({ siteId }) => {
   const { t } = useTranslation(n(site, ['treePage']), {
     nsMode: 'fallback',
   });
@@ -67,7 +63,6 @@ const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({
         title={t('report_sites.hover_title')}
       >
         <ReportIcon />
-        {/* Report Site */}
       </StyledReportButton>
 
       <Modal

--- a/src/components/reportSiteButton/index.tsx
+++ b/src/components/reportSiteButton/index.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback, useState } from 'react';
+import protectedApiClient from '../../api/protectedApiClient';
+import { StyledClose } from '../themedComponents';
+import { ReportSiteRequest } from '../../containers/treePage/ducks/types';
+import { Button, message, Modal, Form } from 'antd';
+import { FlagOutlined } from '@ant-design/icons';
+import ReportSiteForm from '../forms/reportSiteForm';
+import styled from 'styled-components';
+
+const StyledReportButton = styled(Button)`
+  padding-x: 10px;
+  border: none;
+`;
+
+const UnadoptButton = styled(Button)`
+  & :hover {
+    background-color: #fff1f1;
+  }
+`;
+
+const ReportIcon = styled(FlagOutlined)`
+  max-height: 20px;
+  font-size: 15px;
+`;
+
+interface ReportSiteButtonProps {
+  siteId: number;
+  mobile?: boolean;
+}
+
+const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({
+  siteId,
+  mobile,
+}) => {
+  const [showReportModal, setShowReportModal] = useState<boolean>(false);
+  const [reportSiteForm] = Form.useForm();
+
+  const reportSite = useCallback(
+    (reportInfo: ReportSiteRequest) => {
+      protectedApiClient.reportSiteForIssues(siteId, reportInfo).then(() => {
+        message.success('Thank you for your report! SFTT has been notified');
+        setShowReportModal(false);
+      });
+    },
+    [setShowReportModal],
+  );
+
+  return (
+    <>
+      <UnadoptButton
+        danger
+        size="middle"
+        onClick={() => setShowReportModal(!showReportModal)}
+      >
+        <ReportIcon />
+        Report Site
+      </UnadoptButton>
+
+      <Modal
+        open={showReportModal}
+        title="Report Site For Issues"
+        onCancel={() => setShowReportModal(false)}
+        footer={null}
+        closeIcon={<StyledClose />}
+      >
+        <ReportSiteForm
+          form={reportSiteForm}
+          onFinish={reportSite}
+        ></ReportSiteForm>
+      </Modal>
+    </>
+  );
+};
+
+export default ReportSiteButton;

--- a/src/components/reportSiteButton/index.tsx
+++ b/src/components/reportSiteButton/index.tsx
@@ -6,21 +6,23 @@ import { Button, message, Modal, Form } from 'antd';
 import { FlagOutlined } from '@ant-design/icons';
 import ReportSiteForm from '../forms/reportSiteForm';
 import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { site } from '../../constants';
+import { n } from '../../utils/stringFormat';
 
 const StyledReportButton = styled(Button)`
-  padding-x: 10px;
+  padding: 0 10px;
   border: none;
-`;
 
-const UnadoptButton = styled(Button)`
   & :hover {
     background-color: #fff1f1;
   }
 `;
 
 const ReportIcon = styled(FlagOutlined)`
-  max-height: 20px;
-  font-size: 15px;
+  max-height: 25px;
+  font-size: 20px;
+  vertical-align: middle;
 `;
 
 interface ReportSiteButtonProps {
@@ -32,33 +34,45 @@ const ReportSiteButton: React.FC<ReportSiteButtonProps> = ({
   siteId,
   mobile,
 }) => {
+  const { t } = useTranslation(n(site, ['treePage']), {
+    nsMode: 'fallback',
+  });
+
   const [showReportModal, setShowReportModal] = useState<boolean>(false);
   const [reportSiteForm] = Form.useForm();
 
   const reportSite = useCallback(
     (reportInfo: ReportSiteRequest) => {
-      protectedApiClient.reportSiteForIssues(siteId, reportInfo).then(() => {
-        message.success('Thank you for your report! SFTT has been notified');
-        setShowReportModal(false);
-      });
+      protectedApiClient
+        .reportSiteForIssues(siteId, reportInfo)
+        .then(() => {
+          message.success(t('messages.report_success'));
+          setShowReportModal(false);
+        })
+        .catch((err) => {
+          message.error(
+            t('messages.report_failure', { error: err.response.data }),
+          );
+        });
     },
     [setShowReportModal],
   );
 
   return (
     <>
-      <UnadoptButton
+      <StyledReportButton
         danger
         size="middle"
         onClick={() => setShowReportModal(!showReportModal)}
+        title={t('report_sites.hover_title')}
       >
         <ReportIcon />
-        Report Site
-      </UnadoptButton>
+        {/* Report Site */}
+      </StyledReportButton>
 
       <Modal
         open={showReportModal}
-        title="Report Site For Issues"
+        title={t('report_sites.modal_title')}
         onCancel={() => setShowReportModal(false)}
         footer={null}
         closeIcon={<StyledClose />}

--- a/src/components/treePage/treeInfo.tsx
+++ b/src/components/treePage/treeInfo.tsx
@@ -169,7 +169,7 @@ export const TreeInfo: React.FC<TreeProps> = ({
             <UploadSiteImageButton siteEntryId={siteData.entries[0].id} />
           )} */}
 
-          <ReportSiteButton siteId={siteData.siteId} mobile={mobile} />
+          <ReportSiteButton siteId={siteData.siteId} />
 
           {userOwnsTree && treePresent && (
             <StewardshipContainer>

--- a/src/components/treePage/treeInfo.tsx
+++ b/src/components/treePage/treeInfo.tsx
@@ -21,6 +21,7 @@ import { n } from '../../utils/stringFormat';
 import { isSFTT } from '../../utils/isCheck';
 import { getCommonName } from '../../utils/treeFunctions';
 import UploadSiteImageButton from '../uploadSiteImageButton';
+import ReportSiteButton from '../reportSiteButton';
 
 const TreeHeader = styled.div`
   text-transform: capitalize;
@@ -167,6 +168,8 @@ export const TreeInfo: React.FC<TreeProps> = ({
           {/* {treePresent && (
             <UploadSiteImageButton siteEntryId={siteData.entries[0].id} />
           )} */}
+
+          <ReportSiteButton siteId={siteData.siteId} mobile={mobile} />
 
           {userOwnsTree && treePresent && (
             <StewardshipContainer>

--- a/src/containers/treePage/ducks/types.ts
+++ b/src/containers/treePage/ducks/types.ts
@@ -286,6 +286,11 @@ export interface ActivityLog extends ActivityRequest {
   userId: number;
 }
 
+export interface ReportSiteRequest {
+  reason: string;
+  description: string;
+}
+
 export interface AdoptedSites {
   adoptedSites: number[];
 }

--- a/src/containers/treePage/index.tsx
+++ b/src/containers/treePage/index.tsx
@@ -28,6 +28,7 @@ import {
 import {
   asyncRequestIsComplete,
   asyncRequestIsFailed,
+  AsyncRequestKinds,
 } from '../../utils/asyncRequest';
 import { C4CState } from '../../store';
 import { getAdoptedSites, getSiteData } from './ducks/thunks';
@@ -473,7 +474,12 @@ const TreePlantingRequest: React.FC = () => {
 const mapStateToProps = (state: C4CState): TreeProps => {
   return {
     neighborhoods: state.mapGeoDataState.neighborhoodGeoData,
-    sites: state.mapGeoDataState.siteGeoData,
+    // sites: state.mapGeoDataState.siteGeoData,
+    // TODO: return to normal after fixing map speed
+    sites: {
+      kind: AsyncRequestKinds.Completed,
+      result: { type: 'FeatureCollection', name: 'sites', features: [] },
+    },
     tokens: state.authenticationState.tokens,
     siteData: state.siteState.siteData,
     stewardship: mapStewardshipToTreeCare(

--- a/src/i18n/en/forms.json
+++ b/src/i18n/en/forms.json
@@ -147,5 +147,14 @@
     "body_required": "The email body is required",
     "body_placeholder": "Email Body",
     "send": "Send Email"
+  },
+  "report_site": {
+    "options": {
+      "inappropriate": "Inappropriate Content",
+      "incorrect": "Incorrect Information"
+    },
+    "reason_label": "Reason",
+    "description_label": "Description (optional)",
+    "description_placeholder": "Describe the issue in greater detail"
   }
 }

--- a/src/i18n/en/forms.json
+++ b/src/i18n/en/forms.json
@@ -155,6 +155,7 @@
     },
     "reason_label": "Reason",
     "description_label": "Description (optional)",
-    "description_placeholder": "Describe the issue in greater detail"
+    "description_placeholder": "Describe the issue in greater detail",
+    "reason_rule": "A reason is required!"
   }
 }

--- a/src/i18n/en/treePage/treePage.json
+++ b/src/i18n/en/treePage/treePage.json
@@ -22,7 +22,9 @@
     "edit_name_success": "Tree name changed!",
     "edit_name_failure": "Failed to name site: {{error}}",
     "force_unadopt_success": "Force unadopted site!",
-    "force_unadopt_failure": "Failed to force unadopt site: {{error}}"
+    "force_unadopt_failure": "Failed to force unadopt site: {{error}}",
+    "report_success": "Thank you for your report! SFTT has been notified",
+    "report_failure": "Error submitting report: {{error}}"
   },
   "site_image": {
     "uploaded_by": "Uploaded by {{uploader}}",
@@ -55,5 +57,9 @@
     "unsupported_browser": "This browser type is not supported.",
     "learn_more": "Learn more about how we got these numbers <learnMore>here</learnMore>.",
     "not_available": "N/A"
+  },
+  "report_sites": {
+    "hover_title": "Report this site for issues",
+    "modal_title": "Report Site For Issues"
   }
 }


### PR DESCRIPTION
## Checklist

- [x] 1. Run `yarn run check`
- [x] 2. Run `yarn run test`

## Why

Resolves #<Add your ticket number here>

Allows users to make report a site for issues: incorrect information displayed, or inappropriate content (tree name/pictures)
See also: https://github.com/Code-4-Community/speak-for-the-trees-backend-v2/pull/230

## This PR

- Adds the `ReportSiteButton` and `ReportSiteForm` components to allow for site reporting
- Stub `siteData` prop on the tree page
  - Map on page needs to load every site marker even though only a small portion is shown, which dramatically slows down the page - temporary fix until we figure out how to make the map more performant

## Screenshots

<!-- Provide screenshots of any new components, styling changes, or pages. -->

Button on page:
![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/7af0ffda-a82e-46ea-97ee-3c3b784fbca0)

Form in modal:

![image](https://github.com/Code-4-Community/speak-for-the-trees-frontend/assets/68914997/4ca2d988-1f8b-45bf-aa04-5d53f988328a)


## Verification Steps

<!-- What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. -->

- Verified submitting is disabled when no reason is given
- Verified submitting form calls API route to send report email